### PR TITLE
Added logic to ignore unmarked fields when generating list of properties

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -132,6 +132,9 @@ func reflectStruct(definitions Definitions, t reflect.Type) *Type {
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
 		name, required := reflectFieldName(f)
+		if name == "" {
+			continue
+		}
 		st.Properties[name] = reflectTypeToSchema(definitions, f.Type)
 		if required {
 			st.Required = append(st.Required, name)
@@ -141,10 +144,10 @@ func reflectStruct(definitions Definitions, t reflect.Type) *Type {
 }
 
 func reflectFieldName(f reflect.StructField) (string, bool) {
-	name := f.Name
+	var name string
 	required := true
 	parts := strings.Split(f.Tag.Get("json"), ",")
-	if parts[0] != "" {
+	if parts[0] != "" && parts[0] != "-" {
 		name = parts[0]
 	}
 	if len(parts) > 1 && parts[1] == "omitempty" {

--- a/reflect.go
+++ b/reflect.go
@@ -144,12 +144,18 @@ func reflectStruct(definitions Definitions, t reflect.Type) *Type {
 }
 
 func reflectFieldName(f reflect.StructField) (string, bool) {
-	var name string
-	required := true
 	parts := strings.Split(f.Tag.Get("json"), ",")
-	if parts[0] != "" && parts[0] != "-" {
+	if parts[0] == "-" {
+		return "", false
+	}
+
+	name := f.Name
+	required := true
+
+	if parts[0] != "" {
 		name = parts[0]
 	}
+
 	if len(parts) > 1 && parts[1] == "omitempty" {
 		required = false
 	}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -34,13 +34,20 @@ func TestIgnoredProperties(t *testing.T) {
 		"friends":    true,
 		"tags":       true,
 		"birth_date": true,
+		"TestFlag":   true,
 	}
 
 	props := s.Definitions["TestUser"].Properties
 
 	for defKey := range props {
 		if _, ok := expectedProperties[defKey]; !ok {
-			t.Fatalf("unexpected property %s", defKey)
+			t.Fatalf("unexpected property '%s'", defKey)
+		}
+	}
+
+	for defKey := range expectedProperties {
+		if _, ok := props[defKey]; !ok {
+			t.Fatalf("expected property missing '%s'", defKey)
 		}
 	}
 }

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -13,10 +13,34 @@ type TestUser struct {
 	Friends   []int                  `json:"friends,omitempty"`
 	Tags      map[string]interface{} `json:"tags,omitempty"`
 	BirthDate time.Time              `json:"birth_date,omitempty"`
+
+	TestFlag       bool
+	IgnoredCounter int `json:"-"`
 }
 
 func TestJSONSchema(t *testing.T) {
 	s := Reflect(&TestUser{})
 	b, _ := json.MarshalIndent(s, "", "  ")
 	fmt.Printf("%s\n", b)
+}
+
+// TestIgnoredProperties checks if fields with "-" tag or no json tag are ignored
+func TestIgnoredProperties(t *testing.T) {
+	s := Reflect(&TestUser{})
+
+	expectedProperties := map[string]bool{
+		"id":         true,
+		"name":       true,
+		"friends":    true,
+		"tags":       true,
+		"birth_date": true,
+	}
+
+	props := s.Definitions["TestUser"].Properties
+
+	for defKey := range props {
+		if _, ok := expectedProperties[defKey]; !ok {
+			t.Fatalf("unexpected property %s", defKey)
+		}
+	}
 }


### PR DESCRIPTION
Do we need to process unmarked fields in structs? Most probably not :) This PR fixes the issue