### PR TITLE
Unexported and anonymous fields support

### DIFF
--- a/reflect_test.go
+++ b/reflect_test.go
@@ -45,23 +45,28 @@ type TestUser struct {
 func TestSchemaGeneration(t *testing.T) {
 	s := Reflect(&TestUser{})
 
-	expectedProperties := map[string]bool{
-		"id":                       true,
-		"name":                     true,
-		"friends":                  true,
-		"tags":                     true,
-		"birth_date":               true,
-		"TestFlag":                 true,
-		"some_base_property":       true,
-		"grand":                    true,
-		"SomeUntaggedBaseProperty": true,
+	expectedProperties := map[string]string{
+		"id":                       "integer",
+		"name":                     "string",
+		"friends":                  "array",
+		"tags":                     "object",
+		"birth_date":               "string",
+		"TestFlag":                 "boolean",
+		"some_base_property":       "integer",
+		"grand":                    "#/definitions/GrandfatherType",
+		"SomeUntaggedBaseProperty": "boolean",
 	}
 
 	props := s.Definitions["TestUser"].Properties
-
-	for defKey := range props {
-		if _, ok := expectedProperties[defKey]; !ok {
+	for defKey, prop := range props {
+		typeOrRef, ok := expectedProperties[defKey]
+		if !ok {
 			t.Fatalf("unexpected property '%s'", defKey)
+		}
+		if prop.Type != "" && prop.Type != typeOrRef {
+			t.Fatalf("expected property type '%s', got '%s' for property '%s'", typeOrRef, prop.Type, defKey)
+		} else if prop.Ref != "" && prop.Ref != typeOrRef {
+			t.Fatalf("expected reference to '%s', got '%s' for property '%s'", typeOrRef, prop.Ref, defKey)
 		}
 	}
 

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -1,13 +1,33 @@
 package jsonschema
 
 import (
-	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 )
 
+type GrandfatherType struct {
+	FamilyName string `json:"family_name"`
+}
+
+type SomeBaseType struct {
+	SomeBaseProperty        int             `json:"some_base_property"`
+	somePrivateBaseProperty string          `json:"i_am_private"`
+	SomeIgnoredBaseProperty string          `json:"-"`
+	Grandfather             GrandfatherType `json:"grand"`
+
+	SomeUntaggedBaseProperty           bool
+	someUnexportedUntaggedBaseProperty bool
+}
+
+type nonExported struct {
+	PublicNonExported  int
+	privateNonExported int
+}
+
 type TestUser struct {
+	SomeBaseType
+	nonExported
+
 	ID        int                    `json:"id"`
 	Name      string                 `json:"name"`
 	Friends   []int                  `json:"friends,omitempty"`
@@ -18,23 +38,23 @@ type TestUser struct {
 	IgnoredCounter int `json:"-"`
 }
 
-func TestJSONSchema(t *testing.T) {
-	s := Reflect(&TestUser{})
-	b, _ := json.MarshalIndent(s, "", "  ")
-	fmt.Printf("%s\n", b)
-}
-
-// TestIgnoredProperties checks if fields with "-" tag or no json tag are ignored
-func TestIgnoredProperties(t *testing.T) {
+// TestSchemaGeneration checks if schema generated correctly:
+// - fields marked with "-" are ignored
+// - non-exported fields are ignored
+// - anonymous fields are expanded
+func TestSchemaGeneration(t *testing.T) {
 	s := Reflect(&TestUser{})
 
 	expectedProperties := map[string]bool{
-		"id":         true,
-		"name":       true,
-		"friends":    true,
-		"tags":       true,
-		"birth_date": true,
-		"TestFlag":   true,
+		"id":                       true,
+		"name":                     true,
+		"friends":                  true,
+		"tags":                     true,
+		"birth_date":               true,
+		"TestFlag":                 true,
+		"some_base_property":       true,
+		"grand":                    true,
+		"SomeUntaggedBaseProperty": true,
 	}
 
 	props := s.Definitions["TestUser"].Properties


### PR DESCRIPTION
The problem was: the package processes anonymous and non-exported fields of structures incorrectly. That is, non-exported fields were are visible in the output (they should not) and anonymous fields are treated like normal ones and included as separate types into the schema. Base type must extend with anonymous fields, not receive a reference to new type. I'm talking about following situation:
```
type A struct {
  FieldA int
}

type B struct {
  A
  FieldB int
}
```

Currently json schema will contain both types A and B and type B will have 2 properties: `FieldB` (integer) and `A` (reference to type `A`), but there should be only 1 type `B` with 2 properties: `FieldA` and `FieldB`.