### PR TITLE
Optionally specify required struct fields using a jsonschema tag

### DIFF
--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
+  "$ref": "#\/definitions\/TestUser",
+  "definitions": {
+    "GrandfatherType": {
+      "required": [
+        "family_name"
+      ],
+      "properties": {
+        "family_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "type": "object"
+    },
+    "TestUser": {
+      "required": [
+        "some_base_property",
+        "grand",
+        "SomeUntaggedBaseProperty",
+        "id",
+        "name",
+        "TestFlag"
+      ],
+      "properties": {
+        "SomeUntaggedBaseProperty": {
+          "type": "boolean"
+        },
+        "TestFlag": {
+          "type": "boolean"
+        },
+        "birth_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "feeling": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "friends": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "grand": {
+          "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
+          "$ref": "#\/definitions\/GrandfatherType"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "network_address": {
+          "type": "string",
+          "format": "ipv4"
+        },
+        "photo": {
+          "type": "string",
+          "media": {
+            "binaryEncoding": "base64"
+          }
+        },
+        "some_base_property": {
+          "type": "integer"
+        },
+        "tags": {
+          "patternProperties": {
+            ".*": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "website": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "additionalProperties": true,
+      "type": "object"
+    }
+  }
+}

--- a/fixtures/defaults.json
+++ b/fixtures/defaults.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
+  "$ref": "#\/definitions\/TestUser",
+  "definitions": {
+    "GrandfatherType": {
+      "required": [
+        "family_name"
+      ],
+      "properties": {
+        "family_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "TestUser": {
+      "required": [
+        "some_base_property",
+        "grand",
+        "SomeUntaggedBaseProperty",
+        "id",
+        "name",
+        "TestFlag"
+      ],
+      "properties": {
+        "SomeUntaggedBaseProperty": {
+          "type": "boolean"
+        },
+        "TestFlag": {
+          "type": "boolean"
+        },
+        "birth_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "feeling": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "friends": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "grand": {
+          "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
+          "$ref": "#\/definitions\/GrandfatherType"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "network_address": {
+          "type": "string",
+          "format": "ipv4"
+        },
+        "photo": {
+          "type": "string",
+          "media": {
+            "binaryEncoding": "base64"
+          }
+        },
+        "some_base_property": {
+          "type": "integer"
+        },
+        "tags": {
+          "patternProperties": {
+            ".*": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "website": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
+  "$ref": "#\/definitions\/TestUser",
+  "definitions": {
+    "GrandfatherType": {
+      "required": [
+        "family_name"
+      ],
+      "properties": {
+        "family_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "TestUser": {
+      "required": [
+        "SomeUntaggedBaseProperty",
+        "id",
+        "name",
+        "photo"
+      ],
+      "properties": {
+        "SomeUntaggedBaseProperty": {
+          "type": "boolean"
+        },
+        "TestFlag": {
+          "type": "boolean"
+        },
+        "birth_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "feeling": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "friends": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "grand": {
+          "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
+          "$ref": "#\/definitions\/GrandfatherType"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "network_address": {
+          "type": "string",
+          "format": "ipv4"
+        },
+        "photo": {
+          "type": "string",
+          "media": {
+            "binaryEncoding": "base64"
+          }
+        },
+        "some_base_property": {
+          "type": "integer"
+        },
+        "tags": {
+          "patternProperties": {
+            ".*": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "website": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
As opposed to inferring that fields that are tagged `json:",omitempty"` are not required. This allows schemas (which I see as primarily useful when unmarshaling JSON) to be decoupled from how structs are marshaled.

This PR also includes a commit that updates the tests to ensure the `Reflector` options do the right thing when set.