### PR TITLE
Expanded toplevel struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ type TestUser struct {
 }
 ```
 
-Results in this JSON Schema:
+Results in following JSON Schema:
+
+```go
+jsonschema.Reflect(&TestUser{})
+```
 
 ```json
 {
@@ -58,5 +62,70 @@ Results in this JSON Schema:
       "required": ["id", "name"]
     }
   }
+}
+```
+# flags
+* ExpandedStruct
+	If set, makes the top level struct not to reference itself in the definitions
+
+```go
+type GrandfatherType struct {
+	FamilyName string `json:"family_name" jsonschema:"required"`
+}
+
+type SomeBaseType struct {
+	SomeBaseProperty int `json:"some_base_property"`
+	// The jsonschema required tag is nonsensical for private and ignored properties.
+	// Their presence here tests that the fields *will not* be required in the output
+	// schema, even if they are tagged required.
+	somePrivateBaseProperty string          `json:"i_am_private" jsonschema:"required"`
+	SomeIgnoredBaseProperty string          `json:"-" jsonschema:"required"`
+	Grandfather             GrandfatherType `json:"grand"`
+
+	SomeUntaggedBaseProperty           bool `jsonschema:"required"`
+	someUnexportedUntaggedBaseProperty bool
+}
+
+r := jsonschema.Reflector{ExpandedStruct: true}
+r.ReflectStruct(SomeBaseType{})
+```
+
+will result in
+
+```json
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"required": [
+		"some_base_property",
+		"grand",
+		"SomeUntaggedBaseProperty"
+	],
+	"properties": {
+		"SomeUntaggedBaseProperty": {
+			"type": "boolean"
+		},
+		"grand": {
+			"$schema": "http://json-schema.org/draft-04/schema#",
+			"$ref": "#/definitions/GrandfatherType"
+		},
+		"some_base_property": {
+			"type": "integer"
+		}
+	},
+	"type": "object",
+	"definitions": {
+		"GrandfatherType": {
+			"required": [
+				"family_name"
+			],
+			"properties": {
+				"family_name": {
+					"type": "string"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		}
+	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -64,9 +64,13 @@ jsonschema.Reflect(&TestUser{})
   }
 }
 ```
-# flags
-* ExpandedStruct
-	If set, makes the top level struct not to reference itself in the definitions
+## Configurable behaviour
+	The behaviour of the schema generator can be altered with parameters when a `jsonschema.Reflector`
+	instance is created.
+#### ExpandedStruct
+If set to ```true```, makes the top level struct not to reference itself in the definitions. But type passed should be a struct type.
+
+example:
 
 ```go
 type GrandfatherType struct {
@@ -78,54 +82,52 @@ type SomeBaseType struct {
 	// The jsonschema required tag is nonsensical for private and ignored properties.
 	// Their presence here tests that the fields *will not* be required in the output
 	// schema, even if they are tagged required.
-	somePrivateBaseProperty string          `json:"i_am_private" jsonschema:"required"`
-	SomeIgnoredBaseProperty string          `json:"-" jsonschema:"required"`
-	Grandfather             GrandfatherType `json:"grand"`
-
-	SomeUntaggedBaseProperty           bool `jsonschema:"required"`
+	somePrivateBaseProperty            string `json:"i_am_private" jsonschema:"required"`
+	SomeIgnoredBaseProperty            string `json:"-" jsonschema:"required"`
+	SomeUntaggedBaseProperty           bool   `jsonschema:"required"`
 	someUnexportedUntaggedBaseProperty bool
+	Grandfather                        GrandfatherType `json:"grand"`
 }
 
-r := jsonschema.Reflector{ExpandedStruct: true}
-r.ReflectStruct(SomeBaseType{})
+
 ```
 
-will result in
+will output:
 
 ```json
 {
-	"$schema": "http://json-schema.org/draft-04/schema#",
-	"required": [
-		"some_base_property",
-		"grand",
-		"SomeUntaggedBaseProperty"
-	],
-	"properties": {
-		"SomeUntaggedBaseProperty": {
-			"type": "boolean"
-		},
-		"grand": {
-			"$schema": "http://json-schema.org/draft-04/schema#",
-			"$ref": "#/definitions/GrandfatherType"
-		},
-		"some_base_property": {
-			"type": "integer"
-		}
-	},
-	"type": "object",
-	"definitions": {
-		"GrandfatherType": {
-			"required": [
-				"family_name"
-			],
-			"properties": {
-				"family_name": {
-					"type": "string"
-				}
+		"$schema": "http://json-schema.org/draft-04/schema#",
+		"required": [
+			"some_base_property",
+			"grand",
+			"SomeUntaggedBaseProperty"
+		],
+		"properties": {
+			"SomeUntaggedBaseProperty": {
+				"type": "boolean"
 			},
-			"additionalProperties": false,
-			"type": "object"
+			"grand": {
+				"$schema": "http://json-schema.org/draft-04/schema#",
+				"$ref": "#/definitions/GrandfatherType"
+			},
+			"some_base_property": {
+				"type": "integer"
+			}
+		},
+		"type": "object",
+		"definitions": {
+			"GrandfatherType": {
+				"required": [
+					"family_name"
+				],
+				"properties": {
+					"family_name": {
+						"type": "string"
+					}
+				},
+				"additionalProperties": false,
+				"type": "object"
+			}
 		}
-	}
 }
 ```

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
+  "required": [
+    "some_base_property",
+    "grand",
+    "SomeUntaggedBaseProperty",
+    "id",
+    "name",
+    "TestFlag"
+  ],
+  "properties": {
+    "SomeUntaggedBaseProperty": {
+      "type": "boolean"
+    },
+    "TestFlag": {
+      "type": "boolean"
+    },
+    "birth_date": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "feeling": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "friends": {
+      "items": {
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "grand": {
+      "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
+      "$ref": "#\/definitions\/GrandfatherType"
+    },
+    "id": {
+      "type": "integer"
+    },
+    "name": {
+      "type": "string"
+    },
+    "network_address": {
+      "type": "string",
+      "format": "ipv4"
+    },
+    "photo": {
+      "type": "string",
+      "media": {
+        "binaryEncoding": "base64"
+      }
+    },
+    "some_base_property": {
+      "type": "integer"
+    },
+    "tags": {
+      "patternProperties": {
+        ".*": {
+          "additionalProperties": true,
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "website": {
+      "type": "string",
+      "format": "uri"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "definitions": {
+    "GrandfatherType": {
+      "required": [
+        "family_name"
+      ],
+      "properties": {
+        "family_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/reflect.go
+++ b/reflect.go
@@ -71,12 +71,12 @@ type Type struct {
 }
 
 // Reflect reflects to Schema from a value using the default Reflector
-func Reflect(v interface{}) interface{} {
+func Reflect(v interface{}) *Schema {
 	return ReflectFromType(reflect.TypeOf(v))
 }
 
 // ReflectFromType generates root schema using the default Reflector
-func ReflectFromType(t reflect.Type) interface{} {
+func ReflectFromType(t reflect.Type) *Schema {
 	r := &Reflector{}
 	return r.ReflectFromType(t)
 }
@@ -101,12 +101,12 @@ type Reflector struct {
 }
 
 // Reflect reflects to Schema from a value.
-func (r *Reflector) Reflect(v interface{}) interface{} {
+func (r *Reflector) Reflect(v interface{}) *Schema {
 	return r.ReflectFromType(reflect.TypeOf(v))
 }
 
 // ReflectFromType generates root schema
-func (r *Reflector) ReflectFromType(t reflect.Type) interface{} {
+func (r *Reflector) ReflectFromType(t reflect.Type) *Schema {
 	definitions := Definitions{}
 	if r.ExpandedStruct {
 		st := &Type{
@@ -114,7 +114,6 @@ func (r *Reflector) ReflectFromType(t reflect.Type) interface{} {
 			Type:                 "object",
 			Properties:           map[string]*Type{},
 			AdditionalProperties: []byte("false"),
-			Definitions:          definitions,
 		}
 		if r.AllowAdditionalProperties {
 			st.AdditionalProperties = []byte("true")
@@ -122,7 +121,7 @@ func (r *Reflector) ReflectFromType(t reflect.Type) interface{} {
 		r.reflectStructFields(st, definitions, t)
 		r.reflectStruct(definitions, t)
 		delete(definitions, t.Name())
-		return st
+		return &Schema{Type: st, Definitions: definitions}
 	}
 
 	s := &Schema{

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -101,3 +101,26 @@ func TestSchemaGeneration(t *testing.T) {
 		}
 	}
 }
+
+// The reflect here returns a *Type instance
+func TestExpandedStruct(t *testing.T) {
+	r := &Reflector{ExpandedStruct: true}
+	fixture := "fixtures/defaults_expanded_toplevel.json"
+	f, err := ioutil.ReadFile(fixture)
+	if err != nil {
+		t.Errorf("ioutil.ReadAll(%s): %s", fixture, err)
+	}
+	actualSchema := r.Reflect(&TestUser{})
+	expectedSchema := &Type{}
+	if err := json.Unmarshal(f, expectedSchema); err != nil {
+		t.Errorf("json.Unmarshal(%s, %v): %s", fixture, expectedSchema, err)
+	}
+
+	if !reflect.DeepEqual(actualSchema, expectedSchema) {
+		actualJSON, err := json.MarshalIndent(actualSchema, "", "  ")
+		if err != nil {
+			t.Errorf("json.MarshalIndent(%v, \"\", \"  \"): %v", actualSchema, err)
+		}
+		t.Errorf("reflector %+v wanted schema %s, got %s", r, f, actualJSON)
+	}
+}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -72,6 +72,7 @@ var schemaGenerationTests = []struct {
 	{&Reflector{}, "fixtures/defaults.json"},
 	{&Reflector{AllowAdditionalProperties: true}, "fixtures/allow_additional_props.json"},
 	{&Reflector{RequiredFromJSONSchemaTags: true}, "fixtures/required_from_jsontags.json"},
+	{&Reflector{ExpandedStruct: true}, "fixtures/defaults_expanded_toplevel.json"},
 }
 
 func TestSchemaGeneration(t *testing.T) {
@@ -99,28 +100,5 @@ func TestSchemaGeneration(t *testing.T) {
 			}
 			t.Errorf("reflector %+v wanted schema %s, got %s", tt.reflector, f, actualJSON)
 		}
-	}
-}
-
-// The reflect here returns a *Type instance
-func TestExpandedStruct(t *testing.T) {
-	r := &Reflector{ExpandedStruct: true}
-	fixture := "fixtures/defaults_expanded_toplevel.json"
-	f, err := ioutil.ReadFile(fixture)
-	if err != nil {
-		t.Errorf("ioutil.ReadAll(%s): %s", fixture, err)
-	}
-	actualSchema := r.Reflect(&TestUser{})
-	expectedSchema := &Type{}
-	if err := json.Unmarshal(f, expectedSchema); err != nil {
-		t.Errorf("json.Unmarshal(%s, %v): %s", fixture, expectedSchema, err)
-	}
-
-	if !reflect.DeepEqual(actualSchema, expectedSchema) {
-		actualJSON, err := json.MarshalIndent(actualSchema, "", "  ")
-		if err != nil {
-			t.Errorf("json.MarshalIndent(%v, \"\", \"  \"): %v", actualSchema, err)
-		}
-		t.Errorf("reflector %+v wanted schema %s, got %s", r, f, actualJSON)
 	}
 }


### PR DESCRIPTION
The current implementation makes the top level struct to go inside the definition & referenced, this is perfectly fine, However in most ideal situations, the top level schema is expanded like the following example 

```json
{
    "id": "http://some.site.somewhere/entry-schema#",
    "$schema": "http://json-schema.org/draft-04/schema#",
    "description": "schema for an fstab entry",
    "type": "object",
    "required": [ "storage" ],
    "properties": {
        "storage": {
            "type": "object",
            "oneOf": [
                { "$ref": "#/definitions/diskDevice" },
                { "$ref": "#/definitions/diskUUID" },
                { "$ref": "#/definitions/nfs" },
                { "$ref": "#/definitions/tmpfs" }
            ]
        },
        "fstype": {
            "enum": [ "ext3", "ext4", "btrfs" ]
        },
        "options": {
            "type": "array",
            "minItems": 1,
            "items": { "type": "string" },
            "uniqueItems": true
        },
        "readonly": { "type": "boolean" }
    },
    "definitions": {
        "diskDevice": {
            "properties": {
                "type": { "enum": [ "disk" ] },
                "device": {
                    "type": "string",
                    "pattern": "^/dev/[^/]+(/[^/]+)*$"
                }
            },
            "required": [ "type", "device" ],
            "additionalProperties": false
        },
        "diskUUID": {
            "properties": {
                "type": { "enum": [ "disk" ] },
                "label": {
                    "type": "string",
                    "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
                }
            },
            "required": [ "type", "label" ],
            "additionalProperties": false
        },
        "nfs": {
            "properties": {
                "type": { "enum": [ "nfs" ] },
                "remotePath": {
                    "type": "string",
                    "pattern": "^(/[^/]+)+$"
                },
                "server": {
                    "type": "string",
                    "oneOf": [
                        { "format": "host-name" },
                        { "format": "ipv4" },
                        { "format": "ipv6" }
                    ]
                }
            },
            "required": [ "type", "server", "remotePath" ],
            "additionalProperties": false
        },
        "tmpfs": {
            "properties": {
                "type": { "enum": [ "tmpfs" ] },
                "sizeInMB": {
                    "type": "integer",
                    "minimum": 16,
                    "maximum": 512
                }
            },
            "required": [ "type", "sizeInMB" ],
            "additionalProperties": false
        }
    }
}
```
This PR defines a flag `ExpandedStruct` in `Reflector`, when set enables the schema expansion ilke above, Its backward compatible and doesn't disturb the current functionality, 

```go
go test -v
=== RUN   TestSchemaGeneration
--- PASS: TestSchemaGeneration (0.00s)
=== RUN   TestExpandedStruct
--- PASS: TestExpandedStruct (0.00s)
PASS
ok      github.com/shabinesh/jsonschema 0.004s
```
