### PR TITLE
"simple" enum support for "small" strings

### DIFF
--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -57,6 +57,14 @@
             }
           ]
         },
+        "gender": {
+          "enum": [
+            "masculin",
+            "feminin",
+            "other"
+          ],
+          "type": "string"
+        },
         "friends": {
           "items": {
             "type": "integer"

--- a/fixtures/defaults.json
+++ b/fixtures/defaults.json
@@ -57,6 +57,14 @@
             }
           ]
         },
+        "gender": {
+          "enum": [
+            "masculin",
+            "feminin",
+            "other"
+          ],
+          "type": "string"
+        },
         "friends": {
           "items": {
             "type": "integer"

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -42,6 +42,14 @@
         }
       ]
     },
+    "gender": {
+      "enum": [
+        "masculin",
+        "feminin",
+        "other"
+      ],
+      "type": "string"
+    },
     "friends": {
       "items": {
         "type": "integer"

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -53,6 +53,14 @@
             }
           ]
         },
+        "gender": {
+          "enum": [
+            "masculin",
+            "feminin",
+            "other"
+          ],
+          "type": "string"
+        },
         "friends": {
           "items": {
             "type": "integer"

--- a/reflect.go
+++ b/reflect.go
@@ -321,6 +321,13 @@ func (t *Type) stringKeywords(tags []string) {
 					t.Format = val
 					break
 				}
+			case "enum":
+				splits := strings.Split(val, ";")
+				slice := make([]interface{}, len(splits))
+				for i, v := range splits {
+					slice[i] = v
+				}
+				t.Enum = slice
 			}
 		}
 	}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -68,6 +68,8 @@ type TestUser struct {
 	Feeling ProtoEnum `json:"feeling,omitempty"`
 	Age     int       `json:"age" jsonschema:"minimum=18,maximum=120,exclusiveMaximum=true,exclusiveMinimum=true"`
 	Email   string    `json:"email" jsonschema:"format=email"`
+	// Simple enum support (enum in schema, but only string in go property)
+	Gender string `json:"gender,omitempty" jsonschema:"enum=masculin;feminin;other"`
 }
 
 var schemaGenerationTests = []struct {


### PR DESCRIPTION
Hi, I had the need to support enums in strings.

Technically the [enum section](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.1.2) describes the value can be any value. This is probably difficult do handle within a property tag, so for now I added it for strings. This way, the values must be string too.

I don't know about the separator tho, would be nice, if someone could define his separator itself.

I'm open for improvements and ideas