### PR TITLE
Add enum support via interface

### DIFF
--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -97,6 +97,34 @@
           },
           "type": "object"
         },
+        "test_enum_ptr": {
+          "enum": [
+            "d",
+            "e",
+            "f"
+          ]
+        },
+        "test_enum_ptr_ptr": {
+          "enum": [
+            "d",
+            "e",
+            "f"
+          ]
+        },
+        "test_enum_val": {
+          "enum": [
+            "a",
+            "b",
+            "c"
+          ]
+        },
+        "test_enum_val_ptr": {
+          "enum": [
+            "a",
+            "b",
+            "c"
+          ]
+        },
         "website": {
           "type": "string",
           "format": "uri"

--- a/fixtures/defaults.json
+++ b/fixtures/defaults.json
@@ -97,6 +97,34 @@
           },
           "type": "object"
         },
+        "test_enum_ptr": {
+          "enum": [
+            "d",
+            "e",
+            "f"
+          ]
+        },
+        "test_enum_ptr_ptr": {
+          "enum": [
+            "d",
+            "e",
+            "f"
+          ]
+        },
+        "test_enum_val": {
+          "enum": [
+            "a",
+            "b",
+            "c"
+          ]
+        },
+        "test_enum_val_ptr": {
+          "enum": [
+            "a",
+            "b",
+            "c"
+          ]
+        },
         "website": {
           "type": "string",
           "format": "uri"

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -82,6 +82,34 @@
       },
       "type": "object"
     },
+    "test_enum_ptr": {
+      "enum": [
+        "d",
+        "e",
+        "f"
+      ]
+    },
+    "test_enum_ptr_ptr": {
+      "enum": [
+        "d",
+        "e",
+        "f"
+      ]
+    },
+    "test_enum_val": {
+      "enum": [
+        "a",
+        "b",
+        "c"
+      ]
+    },
+    "test_enum_val_ptr": {
+      "enum": [
+        "a",
+        "b",
+        "c"
+      ]
+    },
     "website": {
       "type": "string",
       "format": "uri"

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -93,6 +93,34 @@
           },
           "type": "object"
         },
+        "test_enum_ptr": {
+          "enum": [
+            "d",
+            "e",
+            "f"
+          ]
+        },
+        "test_enum_ptr_ptr": {
+          "enum": [
+            "d",
+            "e",
+            "f"
+          ]
+        },
+        "test_enum_val": {
+          "enum": [
+            "a",
+            "b",
+            "c"
+          ]
+        },
+        "test_enum_val_ptr": {
+          "enum": [
+            "a",
+            "b",
+            "c"
+          ]
+        },
         "website": {
           "type": "string",
           "format": "uri"

--- a/reflect.go
+++ b/reflect.go
@@ -155,6 +155,12 @@ type protoEnum interface {
 
 var protoEnumType = reflect.TypeOf((*protoEnum)(nil)).Elem()
 
+type jsonSchemaEnums interface {
+	JSONSchemaEnums() []interface{}
+}
+
+var jsonSchemaEnumsType = reflect.TypeOf((*jsonSchemaEnums)(nil)).Elem()
+
 func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type) *Type {
 	// Already added to definitions?
 	if _, ok := definitions[t.Name()]; ok {
@@ -168,6 +174,18 @@ func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type)
 			{Type: "string"},
 			{Type: "integer"},
 		}}
+	}
+
+	if t.Implements(jsonSchemaEnumsType) ||
+		(t.Kind() != reflect.Ptr && reflect.PtrTo(t).Implements(jsonSchemaEnumsType)) {
+		if t.Kind() == reflect.Ptr {
+			return &Type{
+				Enum: reflect.New(t.Elem()).Interface().(jsonSchemaEnums).JSONSchemaEnums(),
+			}
+		}
+		return &Type{
+			Enum: reflect.New(t).Interface().(jsonSchemaEnums).JSONSchemaEnums(),
+		}
 	}
 
 	// Defined format types for JSON Schema Validation

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -44,6 +44,18 @@ const (
 	Great
 )
 
+type ABCEnumVal string
+
+func (ABCEnumVal) JSONSchemaEnums() []interface{} {
+	return []interface{}{"a", "b", "c"}
+}
+
+type DEFEnumPtr string
+
+func (*DEFEnumPtr) JSONSchemaEnums() []interface{} {
+	return []interface{}{"d", "e", "f"}
+}
+
 type TestUser struct {
 	SomeBaseType
 	nonExported
@@ -68,6 +80,11 @@ type TestUser struct {
 	Feeling ProtoEnum `json:"feeling,omitempty"`
 	Age     int       `json:"age" jsonschema:"minimum=18,maximum=120,exclusiveMaximum=true,exclusiveMinimum=true"`
 	Email   string    `json:"email" jsonschema:"format=email"`
+
+	TestEnumVal    ABCEnumVal  `json:"test_enum_val,omitempty"`
+	TestEnumValPtr *ABCEnumVal `json:"test_enum_val_ptr,omitempty"`
+	TestEnumPtr    DEFEnumPtr  `json:"test_enum_ptr,omitempty"`
+	TestEnumPtrPtr *DEFEnumPtr `json:"test_enum_ptr_ptr,omitempty"`
 }
 
 var schemaGenerationTests = []struct {


### PR DESCRIPTION
Hello, would this a valid way of adding more flexible enum support? my use case is various enum types that already have string<->int translation maps so `JSONSchemaEnums()` would just be a range loop to collect strings and return them.

Some questions and concerns:

Weird or confusing to create a values from the type and call code when "reflecting"? maybe only support value receiver method?

Support more then one level of pointers?

Support enum type? spec seem to say the type is optional for enum.

TODO:
Document

Related to #23