### PR TITLE
Add support for pattern tag

### DIFF
--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -74,7 +74,8 @@
         "name": {
           "type": "string",
           "maxLength": 20,
-          "minLength": 1
+          "minLength": 1,
+          "pattern": ".*"
         },
         "network_address": {
           "type": "string",

--- a/fixtures/defaults.json
+++ b/fixtures/defaults.json
@@ -74,7 +74,8 @@
         "name": {
           "type": "string",
           "maxLength": 20,
-          "minLength": 1
+          "minLength": 1,
+          "pattern": ".*"
         },
         "network_address": {
           "type": "string",

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -59,7 +59,8 @@
     "name": {
         "type": "string",
         "maxLength": 20,
-        "minLength": 1
+        "minLength": 1,
+        "pattern": ".*"
     },
     "network_address": {
       "type": "string",

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -69,7 +69,8 @@
         "name": {
           "type": "string",
           "maxLength": 20,
-          "minLength": 1
+          "minLength": 1,
+          "pattern": ".*"
         },
         "network_address": {
           "type": "string",

--- a/reflect.go
+++ b/reflect.go
@@ -315,6 +315,8 @@ func (t *Type) stringKeywords(tags []string) {
 			case "maxLength":
 				i, _ := strconv.Atoi(val)
 				t.MaxLength = i
+			case "pattern":
+				t.Pattern = val
 			case "format":
 				switch val {
 				case "date-time", "email", "hostname", "ipv4", "ipv6", "uri":

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -50,7 +50,7 @@ type TestUser struct {
 	nonExported
 
 	ID      int                    `json:"id" jsonschema:"required"`
-	Name    string                 `json:"name" jsonschema:"required,minLength=1,maxLength=20"`
+	Name    string                 `json:"name" jsonschema:"required,minLength=1,maxLength=20,pattern=.*"`
 	Friends []int                  `json:"friends,omitempty"`
 	Tags    map[string]interface{} `json:"tags,omitempty"`
 


### PR DESCRIPTION
This PR allows the definition of structs like:

```go
type Foo struct {
  Bar string `json:"bar" jsonschema:"pattern=abc"`
}
```

Which will generate schemas like:

```
"bar": {
  "pattern": "abc",
  "type": "string"
}
```