### PR TITLE
Fix handling of structs with unnamed fields, add ability to ignore types

### DIFF
--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -14,6 +14,21 @@
       "additionalProperties": true,
       "type": "object"
     },
+    "StructWithUnnamedString": {
+      "required": [
+        "SomeString"
+      ],
+      "properties": {
+        "SomeString": {
+          "type": "string"
+        },
+        "something": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "type": "object"
+    },
     "TestUser": {
       "required": [
         "some_base_property",
@@ -39,6 +54,10 @@
           "exclusiveMaximum": true,
           "exclusiveMinimum": true,
           "type": "integer"
+        },
+        "badstruct": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/StructWithUnnamedString"
         },
         "email": {
           "type": "string",

--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -35,6 +35,7 @@
         "some_base_property_yaml",
         "grand",
         "SomeUntaggedBaseProperty",
+        "MapType",
         "id",
         "name",
         "TestFlag",
@@ -42,6 +43,15 @@
         "email"
       ],
       "properties": {
+        "MapType": {
+          "patternProperties": {
+            ".*": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
         "SomeUntaggedBaseProperty": {
           "type": "boolean"
         },

--- a/fixtures/defaults.json
+++ b/fixtures/defaults.json
@@ -35,6 +35,7 @@
         "some_base_property_yaml",
         "grand",
         "SomeUntaggedBaseProperty",
+        "MapType",
         "id",
         "name",
         "TestFlag",
@@ -42,6 +43,15 @@
         "email"
       ],
       "properties": {
+        "MapType": {
+          "patternProperties": {
+            ".*": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
         "SomeUntaggedBaseProperty": {
           "type": "boolean"
         },

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -5,6 +5,7 @@
     "some_base_property_yaml",
     "grand",
     "SomeUntaggedBaseProperty",
+    "MapType",
     "id",
     "name",
     "TestFlag",
@@ -12,6 +13,15 @@
     "email"
   ],
   "properties": {
+    "MapType": {
+      "patternProperties": {
+        ".*": {
+          "additionalProperties": true,
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
     "SomeUntaggedBaseProperty": {
       "type": "boolean"
     },

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -25,6 +25,10 @@
       "exclusiveMinimum": true,
       "type": "integer"
     },
+    "badstruct": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "$ref": "#/definitions/StructWithUnnamedString"
+    },
     "email": {
       "type": "string",
       "format": "email"
@@ -109,6 +113,21 @@
       ],
       "properties": {
         "family_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "StructWithUnnamedString": {
+      "required": [
+        "SomeString"
+      ],
+      "properties": {
+        "SomeString": {
+          "type": "string"
+        },
+        "something": {
           "type": "string"
         }
       },

--- a/fixtures/ignore_type.json
+++ b/fixtures/ignore_type.json
@@ -15,18 +15,9 @@
       "type": "object"
     },
     "StructWithUnnamedString": {
-      "required": [
-        "SomeString"
-      ],
       "properties": {
-        "SomeString": {
-          "type": "string"
-        },
-        "something": {
-          "type": "string"
-        }
       },
-      "additionalProperties": false,
+      "additionalProperties": true,
       "type": "object"
     },
     "TestUser": {
@@ -81,8 +72,7 @@
           "items": {
             "type": "integer"
           },
-          "type": "array",
-          "description": "list of IDs, omitted when empty"
+          "type": "array"
         },
         "grand": {
           "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
@@ -95,14 +85,7 @@
           "type": "string",
           "maxLength": 20,
           "minLength": 1,
-          "pattern": ".*",
-          "title": "the name",
-          "description": "this is a property",
-          "default": "alex",
-          "examples": [
-            "joe",
-            "lucy"
-          ]
+          "pattern": ".*"
         },
         "network_address": {
           "type": "string",

--- a/fixtures/ignore_type.json
+++ b/fixtures/ignore_type.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
-  "$ref": "#\/definitions\/TestUser",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/TestUser",
   "definitions": {
     "GrandfatherType": {
       "required": [
@@ -26,6 +26,7 @@
         "some_base_property_yaml",
         "grand",
         "SomeUntaggedBaseProperty",
+        "MapType",
         "id",
         "name",
         "TestFlag",
@@ -33,16 +34,25 @@
         "email"
       ],
       "properties": {
+        "MapType": {
+          "patternProperties": {
+            ".*": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
         "SomeUntaggedBaseProperty": {
           "type": "boolean"
         },
         "TestFlag": {
           "type": "boolean"
         },
-        "age":{
+        "age": {
           "maximum": 120,
-          "minimum": 18,
           "exclusiveMaximum": true,
+          "minimum": 18,
           "exclusiveMinimum": true,
           "type": "integer"
         },
@@ -50,13 +60,13 @@
           "$schema": "http://json-schema.org/draft-04/schema#",
           "$ref": "#/definitions/StructWithUnnamedString"
         },
-        "email": {
-          "type": "string",
-          "format": "email"
-        },
         "birth_date": {
           "type": "string",
           "format": "date-time"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
         },
         "feeling": {
           "oneOf": [
@@ -72,20 +82,28 @@
           "items": {
             "type": "integer"
           },
-          "type": "array"
+          "type": "array",
+          "description": "list of IDs, omitted when empty"
         },
         "grand": {
-          "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
-          "$ref": "#\/definitions\/GrandfatherType"
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/GrandfatherType"
         },
         "id": {
           "type": "integer"
         },
         "name": {
-          "type": "string",
           "maxLength": 20,
           "minLength": 1,
-          "pattern": ".*"
+          "pattern": ".*",
+          "type": "string",
+          "title": "the name",
+          "description": "this is a property",
+          "default": "alex",
+          "examples": [
+            "joe",
+            "lucy"
+          ]
         },
         "network_address": {
           "type": "string",

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -34,6 +34,15 @@
         "photo"
       ],
       "properties": {
+        "MapType": {
+          "patternProperties": {
+            ".*": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
         "SomeUntaggedBaseProperty": {
           "type": "boolean"
         },

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -14,6 +14,18 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "StructWithUnnamedString": {
+      "properties": {
+        "SomeString": {
+          "type": "string"
+        },
+        "something": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "TestUser": {
       "required": [
         "SomeUntaggedBaseProperty",
@@ -34,6 +46,10 @@
           "exclusiveMaximum": true,
           "exclusiveMinimum": true,
           "type": "integer"
+        },
+        "badstruct": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/StructWithUnnamedString"
         },
         "email": {
           "type": "string",

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/alecthomas/jsonschema
+
+go 1.12

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -72,6 +72,17 @@ type TestUser struct {
 	Feeling ProtoEnum `json:"feeling,omitempty"`
 	Age     int       `json:"age" jsonschema:"minimum=18,maximum=120,exclusiveMaximum=true,exclusiveMinimum=true"`
 	Email   string    `json:"email" jsonschema:"format=email"`
+
+	// Test for a struct with an unnamed field.
+	BadStruct StructWithUnnamedString `json:"badstruct,omitempty"`
+}
+
+type SomeString string
+
+type StructWithUnnamedString struct {
+	Something string `json:"something,omitempty"`
+
+	SomeString
 }
 
 var schemaGenerationTests = []struct {
@@ -82,6 +93,7 @@ var schemaGenerationTests = []struct {
 	{&Reflector{AllowAdditionalProperties: true}, "fixtures/allow_additional_props.json"},
 	{&Reflector{RequiredFromJSONSchemaTags: true}, "fixtures/required_from_jsontags.json"},
 	{&Reflector{ExpandedStruct: true}, "fixtures/defaults_expanded_toplevel.json"},
+	{&Reflector{IgnoredTypes: []interface{}{StructWithUnnamedString{}}}, "fixtures/ignore_type.json"},
 }
 
 func TestSchemaGeneration(t *testing.T) {


### PR DESCRIPTION
Specifically, things blew up when you tried to generate a schema for https://github.com/kubernetes/api/blob/master/core/v1/types.go#L1866-L1875 - a lot of reflection stuff tends to hate Kubernetes' `resource.Quantity` for some reason. Anyway, this fixes that from exploding, and also adds the ability to allow certain types to be unvalidated.

We're using my fork in https://github.com/jenkins-x/jx/pull/3757 but would definitely prefer to get this in instead. =)