### PR TITLE
Generic keywords support: title, description, examples, default

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ The following Go type:
 ```go
 type TestUser struct {
   ID        int                    `json:"id"`
-  Name      string                 `json:"name"`
-  Friends   []int                  `json:"friends,omitempty"`
+  Name      string                 `json:"name" jsonschema="title=the name,description=The name of a friend,example=joe,example=lucy,default=alex"`
+  Friends   []int                  `json:"friends,omitempty" jsonschema_description:"The list of IDs, omitted when empty"`
   Tags      map[string]interface{} `json:"tags,omitempty"`
   BirthDate time.Time              `json:"birth_date,omitempty"`
 }
@@ -45,13 +45,21 @@ jsonschema.Reflect(&TestUser{})
           "type": "array",
           "items": {
             "type": "integer"
-          }
+          },
+          "description": "The list of IDs, omitted when empty"
         },
         "id": {
           "type": "integer"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "title": "the name",
+          "description": "The name of a friend",
+          "default": "alex",
+          "examples": [
+            "joe",
+            "lucy"
+          ]
         },
         "tags": {
           "type": "object",

--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -39,7 +39,7 @@
           "exclusiveMaximum": true,
           "exclusiveMinimum": true,
           "type": "integer"
-        },  
+        },
         "email": {
           "type": "string",
           "format": "email"
@@ -62,7 +62,8 @@
           "items": {
             "type": "integer"
           },
-          "type": "array"
+          "type": "array",
+          "description": "list of IDs, omitted when empty"
         },
         "grand": {
           "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
@@ -75,7 +76,14 @@
           "type": "string",
           "maxLength": 20,
           "minLength": 1,
-          "pattern": ".*"
+          "pattern": ".*",
+          "title": "the name",
+          "description": "this is a property",
+          "default": "alex",
+          "examples": [
+            "joe",
+            "lucy"
+          ]
         },
         "network_address": {
           "type": "string",

--- a/fixtures/defaults.json
+++ b/fixtures/defaults.json
@@ -39,7 +39,7 @@
           "exclusiveMaximum": true,
           "exclusiveMinimum": true,
           "type": "integer"
-        },  
+        },
         "email": {
           "type": "string",
           "format": "email"
@@ -62,7 +62,8 @@
           "items": {
             "type": "integer"
           },
-          "type": "array"
+          "type": "array",
+          "description": "list of IDs, omitted when empty"
         },
         "grand": {
           "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
@@ -75,7 +76,14 @@
           "type": "string",
           "maxLength": 20,
           "minLength": 1,
-          "pattern": ".*"
+          "pattern": ".*",
+          "title": "the name",
+          "description": "this is a property",
+          "default": "alex",
+          "examples": [
+            "joe",
+            "lucy"
+          ]
         },
         "network_address": {
           "type": "string",

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -24,7 +24,7 @@
       "exclusiveMaximum": true,
       "exclusiveMinimum": true,
       "type": "integer"
-    },  
+    },
     "email": {
       "type": "string",
       "format": "email"
@@ -47,7 +47,8 @@
       "items": {
         "type": "integer"
       },
-      "type": "array"
+      "type": "array",
+      "description": "list of IDs, omitted when empty"
     },
     "grand": {
       "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
@@ -60,7 +61,14 @@
         "type": "string",
         "maxLength": 20,
         "minLength": 1,
-        "pattern": ".*"
+        "pattern": ".*",
+        "title": "the name",
+        "description": "this is a property",
+        "default": "alex",
+        "examples": [
+          "joe",
+          "lucy"
+        ]
     },
     "network_address": {
       "type": "string",

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -34,7 +34,7 @@
           "exclusiveMaximum": true,
           "exclusiveMinimum": true,
           "type": "integer"
-        },  
+        },
         "email": {
           "type": "string",
           "format": "email"
@@ -57,7 +57,8 @@
           "items": {
             "type": "integer"
           },
-          "type": "array"
+          "type": "array",
+          "description": "list of IDs, omitted when empty"
         },
         "grand": {
           "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
@@ -70,7 +71,14 @@
           "type": "string",
           "maxLength": 20,
           "minLength": 1,
-          "pattern": ".*"
+          "pattern": ".*",
+          "title": "the name",
+          "description": "this is a property",
+          "default": "alex",
+          "examples": [
+            "joe",
+            "lucy"
+          ]
         },
         "network_address": {
           "type": "string",

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -50,8 +50,8 @@ type TestUser struct {
 	nonExported
 
 	ID      int                    `json:"id" jsonschema:"required"`
-	Name    string                 `json:"name" jsonschema:"required,minLength=1,maxLength=20,pattern=.*"`
-	Friends []int                  `json:"friends,omitempty"`
+	Name    string                 `json:"name" jsonschema:"required,minLength=1,maxLength=20,pattern=.*,description=this is a property,title=the name,example=joe,example=lucy,default=alex"`
+	Friends []int                  `json:"friends,omitempty" jsonschema_description:"list of IDs, omitted when empty"`
 	Tags    map[string]interface{} `json:"tags,omitempty"`
 
 	TestFlag       bool


### PR DESCRIPTION
Hi there and thanks for a very useful library.

This patch adds some basic support for the generic keywords `title`, `description`, `examples`, `default`.
Let me know if this would be interesting to others,

Thanks!