### PR TITLE
Generic keywords: support `default` and `examples` for simple types and array

### DIFF
--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -38,7 +38,12 @@
           "minimum": 18,
           "exclusiveMaximum": true,
           "exclusiveMinimum": true,
-          "type": "integer"
+          "type": "integer",
+          "default": "1or2",
+          "examples": [
+            3,
+            "four"
+          ]
         },
         "email": {
           "type": "string",
@@ -66,8 +71,8 @@
           "description": "list of IDs, omitted when empty"
         },
         "grand": {
-          "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
-          "$ref": "#\/definitions\/GrandfatherType"
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/GrandfatherType"
         },
         "id": {
           "type": "integer"

--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -28,7 +28,12 @@
       ],
       "properties": {
         "SomeUntaggedBaseProperty": {
-          "type": "boolean"
+          "type": "boolean",
+          "default": false,
+          "examples": [
+            true,
+            "OK"
+          ]
         },
         "TestFlag": {
           "type": "boolean"

--- a/fixtures/defaults.json
+++ b/fixtures/defaults.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
-  "$ref": "#\/definitions\/TestUser",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/TestUser",
   "definitions": {
     "GrandfatherType": {
       "required": [
@@ -33,20 +33,25 @@
         "TestFlag": {
           "type": "boolean"
         },
-        "age":{
+        "age": {
           "maximum": 120,
-          "minimum": 18,
           "exclusiveMaximum": true,
+          "minimum": 18,
           "exclusiveMinimum": true,
-          "type": "integer"
-        },
-        "email": {
-          "type": "string",
-          "format": "email"
+          "type": "integer",
+          "default": "1or2",
+          "examples": [
+            3,
+            "four"
+          ]
         },
         "birth_date": {
           "type": "string",
           "format": "date-time"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
         },
         "feeling": {
           "oneOf": [
@@ -66,8 +71,8 @@
           "description": "list of IDs, omitted when empty"
         },
         "grand": {
-          "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
-          "$ref": "#\/definitions\/GrandfatherType"
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/GrandfatherType"
         },
         "id": {
           "type": "integer"

--- a/fixtures/defaults.json
+++ b/fixtures/defaults.json
@@ -28,7 +28,12 @@
       ],
       "properties": {
         "SomeUntaggedBaseProperty": {
-          "type": "boolean"
+          "type": "boolean",
+          "default": false,
+          "examples": [
+            true,
+            "OK"
+          ]
         },
         "TestFlag": {
           "type": "boolean"

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -23,7 +23,12 @@
       "minimum": 18,
       "exclusiveMaximum": true,
       "exclusiveMinimum": true,
-      "type": "integer"
+      "type": "integer",
+      "default": "1or2",
+      "examples": [
+        3,
+        "four"
+      ]
     },
     "email": {
       "type": "string",
@@ -51,8 +56,8 @@
       "description": "list of IDs, omitted when empty"
     },
     "grand": {
-      "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
-      "$ref": "#\/definitions\/GrandfatherType"
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "$ref": "#/definitions/GrandfatherType"
     },
     "id": {
       "type": "integer"

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -13,7 +13,12 @@
   ],
   "properties": {
     "SomeUntaggedBaseProperty": {
-      "type": "boolean"
+      "type": "boolean",
+      "default": false,
+      "examples": [
+        true,
+        "OK"
+      ]
     },
     "TestFlag": {
       "type": "boolean"

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -33,7 +33,12 @@
           "minimum": 18,
           "exclusiveMaximum": true,
           "exclusiveMinimum": true,
-          "type": "integer"
+          "type": "integer",
+          "default": "1or2",
+          "examples": [
+            3,
+            "four"
+          ]
         },
         "email": {
           "type": "string",
@@ -61,8 +66,8 @@
           "description": "list of IDs, omitted when empty"
         },
         "grand": {
-          "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
-          "$ref": "#\/definitions\/GrandfatherType"
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/GrandfatherType"
         },
         "id": {
           "type": "integer"

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -23,7 +23,12 @@
       ],
       "properties": {
         "SomeUntaggedBaseProperty": {
-          "type": "boolean"
+          "type": "boolean",
+          "default": false,
+          "examples": [
+            true,
+            "OK"
+          ]
         },
         "TestFlag": {
           "type": "boolean"

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,5 @@
 module github.com/alecthomas/jsonschema
+
+go 1.12
+
+require github.com/go-test/deep v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=
+github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/go-test/deep"
 )
 
 type GrandfatherType struct {
@@ -65,9 +67,9 @@ type TestUser struct {
 	// Tests for RFC draft-wright-json-schema-hyperschema-00, section 4
 	Photo []byte `json:"photo,omitempty" jsonschema:"required"`
 
-	// Tests for jsonpb enum support
+	// Tests for jsonpb enum support and a default value that is not valid
 	Feeling ProtoEnum `json:"feeling,omitempty"`
-	Age     int       `json:"age" jsonschema:"minimum=18,maximum=120,exclusiveMaximum=true,exclusiveMinimum=true"`
+	Age     int       `json:"age" jsonschema:"minimum=18,maximum=120,exclusiveMaximum=true,exclusiveMinimum=true,default=1or2,example=3,example=four"`
 	Email   string    `json:"email" jsonschema:"format=email"`
 }
 
@@ -105,7 +107,7 @@ func TestSchemaGeneration(t *testing.T) {
 					t.Errorf("json.MarshalIndent(%v, \"\", \"  \"): %v", actualSchema, err)
 					return
 				}
-				t.Errorf("reflector %+v wanted schema %s, got %s", tt.reflector, f, actualJSON)
+				t.Errorf("unexpected diff: %+v\nreflector %+v wanted schema %s, got %s", deep.Equal(expectedSchema, actualSchema), tt.reflector, f, actualJSON)
 			}
 		})
 	}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -29,7 +29,7 @@ type SomeBaseType struct {
 	SomeSchemaIgnoredProperty string          `jsonschema:"-,required"`
 	Grandfather               GrandfatherType `json:"grand"`
 
-	SomeUntaggedBaseProperty           bool `jsonschema:"required"`
+	SomeUntaggedBaseProperty           bool `jsonschema:"required,example=true,example=OK,default=false"`
 	someUnexportedUntaggedBaseProperty bool
 }
 


### PR DESCRIPTION
Hi there and thanks again for your attention,

I added some tests related to the `examples` and `default` keywords.
It turns out, it takes a lot more introspection to marshall them correctly. At least well enough for simple types and arrays.
I did add a dependency on go-deep to be able to figure out the differences when the tests were failing.

Apologies for rushing in the addition of the generic keywords without testing them more in depth.
And maybe the added complexity is not worth it.
I am happy to look into a simpler implementation with more time or some hints.

And thanks for your attention!