### PR TITLE
feat: add oneof ( required and type ) tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ The following Go type:
 
 ```go
 type TestUser struct {
-  ID        int                    `json:"id"`
-  Name      string                 `json:"name" jsonschema:"title=the name,description=The name of a friend,example=joe,example=lucy,default=alex"`
-  Friends   []int                  `json:"friends,omitempty" jsonschema_description:"The list of IDs, omitted when empty"`
-  Tags      map[string]interface{} `json:"tags,omitempty"`
-  BirthDate time.Time              `json:"birth_date,omitempty"`
+  ID            int                    `json:"id"`
+  Name          string                 `json:"name" jsonschema:"title=the name,description=The name of a friend,example=joe,example=lucy,default=alex"`
+  Friends       []int                  `json:"friends,omitempty" jsonschema_description:"The list of IDs, omitted when empty"`
+  Tags          map[string]interface{} `json:"tags,omitempty"`
+  BirthDate     time.Time              `json:"birth_date,omitempty" jsonschema:"oneof_required=date"`
+  YearOfBirth   string                 `json:"year_of_birth,omitempty" jsonschema:"oneof_required=year"`
+  Metadata      interface{}            `json:"metadata,omitempty" jsonschema:"oneof_type=string;array"`
 }
 ```
 
@@ -37,6 +39,16 @@ jsonschema.Reflect(&TestUser{})
     "TestUser": {
       "type": "object",
       "properties": {
+        "metadata": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
         "birth_date": {
           "type": "string",
           "format": "date-time"
@@ -72,7 +84,21 @@ jsonschema.Reflect(&TestUser{})
         }
       },
       "additionalProperties": false,
-      "required": ["id", "name"]
+      "required": ["id", "name"],
+      "oneOf": [
+        {
+          "required": [
+            "birth_date"
+          ],
+          "title": "date"
+        },
+        {
+          "required": [
+            "year_of_birth"
+          ],
+          "title": "year"
+        }
+      ]
     }
   }
 }

--- a/fixtures/oneof.json
+++ b/fixtures/oneof.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/RootOneOf",
+  "definitions": {
+    "ChildOneOf": {
+      "properties": {
+        "child1": {
+          "type": "string"
+        },
+        "child2": {
+          "type": "string"
+        },
+        "child3": {
+          "additionalProperties": true,
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "child4": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "oneOf": [
+        {
+          "required": [
+            "child1",
+            "child4"
+          ],
+          "title": "group1"
+        },
+        {
+          "required": [
+            "child2"
+          ],
+          "title": "group2"
+        }
+      ]
+    },
+    "RootOneOf": {
+      "properties": {
+        "child": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/ChildOneOf"
+        },
+        "field1": {
+          "type": "string"
+        },
+        "field2": {
+          "type": "string"
+        },
+        "field3": {
+          "additionalProperties": true,
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "field4": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "oneOf": [
+        {
+          "required": [
+            "field1",
+            "field4"
+          ],
+          "title": "group1"
+        },
+        {
+          "required": [
+            "field2"
+          ],
+          "title": "group2"
+        }
+      ]
+    }
+  }
+}

--- a/fixtures/oneof.json
+++ b/fixtures/oneof.json
@@ -37,7 +37,8 @@
         },
         {
           "required": [
-            "child2"
+            "child2",
+            "child3"
           ],
           "title": "group2"
         }

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -83,18 +83,18 @@ type CustomTypeField struct {
 }
 
 type RootOneOf struct {
-	Field1 string      `json:"field1" jsonschema_oneof:"required=group1"`
-	Field2 string      `json:"field2" jsonschema_oneof:"required=group2"`
-	Field3 interface{} `json:"field3" jsonschema_oneof:"type=string,array"`
-	Field4 string      `json:"field4" jsonschema_oneof:"required=group1"`
+	Field1 string      `json:"field1" jsonschema:"oneof_required=group1"`
+	Field2 string      `json:"field2" jsonschema:"oneof_required=group2"`
+	Field3 interface{} `json:"field3" jsonschema:"oneof_type=string;array"`
+	Field4 string      `json:"field4" jsonschema:"oneof_required=group1"`
 	Field5 ChildOneOf  `json:"child"`
 }
 
 type ChildOneOf struct {
-	Child1 string      `json:"child1" jsonschema_oneof:"required=group1"`
-	Child2 string      `json:"child2" jsonschema_oneof:"required=group2"`
-	Child3 interface{} `json:"child3" jsonschema_oneof:"type=string,array"`
-	Child4 string      `json:"child4" jsonschema_oneof:"required=group1"`
+	Child1 string      `json:"child1" jsonschema:"oneof_required=group1"`
+	Child2 string      `json:"child2" jsonschema:"oneof_required=group2"`
+	Child3 interface{} `json:"child3" jsonschema:"oneof_required=group2,oneof_type=string;array"`
+	Child4 string      `json:"child4" jsonschema:"oneof_required=group1"`
 }
 
 func TestSchemaGeneration(t *testing.T) {

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -82,12 +82,28 @@ type CustomTypeField struct {
 	CreatedAt CustomTime
 }
 
+type RootOneOf struct {
+	Field1 string      `json:"field1" jsonschema_oneof:"required=group1"`
+	Field2 string      `json:"field2" jsonschema_oneof:"required=group2"`
+	Field3 interface{} `json:"field3" jsonschema_oneof:"type=string,array"`
+	Field4 string      `json:"field4" jsonschema_oneof:"required=group1"`
+	Field5 ChildOneOf  `json:"child"`
+}
+
+type ChildOneOf struct {
+	Child1 string      `json:"child1" jsonschema_oneof:"required=group1"`
+	Child2 string      `json:"child2" jsonschema_oneof:"required=group2"`
+	Child3 interface{} `json:"child3" jsonschema_oneof:"type=string,array"`
+	Child4 string      `json:"child4" jsonschema_oneof:"required=group1"`
+}
+
 func TestSchemaGeneration(t *testing.T) {
 	tests := []struct {
 		typ       interface{}
 		reflector *Reflector
 		fixture   string
 	}{
+		{&RootOneOf{}, &Reflector{RequiredFromJSONSchemaTags: true}, "fixtures/oneof.json"},
 		{&TestUser{}, &Reflector{}, "fixtures/defaults.json"},
 		{&TestUser{}, &Reflector{AllowAdditionalProperties: true}, "fixtures/allow_additional_props.json"},
 		{&TestUser{}, &Reflector{RequiredFromJSONSchemaTags: true}, "fixtures/required_from_jsontags.json"},


### PR DESCRIPTION
This PR allows you to use oneof for the 2 following use-cases:

- Make fields required by group using the tag `jsonschema:"oneof_required=group1"`. Useful to say that an object required some fields OR some others filed

 Result:
`
"oneOf": [
        {
          "required": [
            "child1",
            "child4"
          ],
          "title": "group1"
        },
        {
          "required": [
            "child2"
          ],
          "title": "group2"
        }
      ]
`

- have field with 2 types using tag `jsonschema:"oneof_type=string,array"`
  Result: `"oneOf": [
            {
              "type": "string"
            },
            {
              "type": "array"
            }
          ]`
