### PR TITLE
Ordered properties

### DIFF
--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -28,38 +28,36 @@
         "email"
       ],
       "properties": {
-        "PublicNonExported": {
+        "some_base_property": {
           "type": "integer"
+        },
+        "some_base_property_yaml": {
+          "type": "integer"
+        },
+        "grand": {
+          "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
+          "$ref": "#\/definitions\/GrandfatherType"
         },
         "SomeUntaggedBaseProperty": {
           "type": "boolean"
         },
-        "TestFlag": {
-          "type": "boolean"
-        },
-        "age":{
-          "maximum": 120,
-          "minimum": 18,
-          "exclusiveMaximum": true,
-          "exclusiveMinimum": true,
+        "PublicNonExported": {
           "type": "integer"
         },
-        "email": {
-          "type": "string",
-          "format": "email"
+        "id": {
+          "type": "integer"
         },
-        "birth_date": {
+        "name": {
+          "maxLength": 20,
+          "minLength": 1,
+          "pattern": ".*",
           "type": "string",
-          "format": "date-time"
-        },
-        "feeling": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "integer"
-            }
+          "title": "the name",
+          "description": "this is a property",
+          "default": "alex",
+          "examples": [
+            "joe",
+            "lucy"
           ]
         },
         "friends": {
@@ -69,25 +67,25 @@
           "type": "array",
           "description": "list of IDs, omitted when empty"
         },
-        "grand": {
-          "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
-          "$ref": "#\/definitions\/GrandfatherType"
+        "tags": {
+          "patternProperties": {
+            ".*": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "type": "object"
         },
-        "id": {
-          "type": "integer"
+        "TestFlag": {
+          "type": "boolean"
         },
-        "name": {
+        "birth_date": {
           "type": "string",
-          "maxLength": 20,
-          "minLength": 1,
-          "pattern": ".*",
-          "title": "the name",
-          "description": "this is a property",
-          "default": "alex",
-          "examples": [
-            "joe",
-            "lucy"
-          ]
+          "format": "date-time"
+        },
+        "website": {
+          "type": "string",
+          "format": "uri"
         },
         "network_address": {
           "type": "string",
@@ -99,24 +97,26 @@
             "binaryEncoding": "base64"
           }
         },
-        "some_base_property": {
-          "type": "integer"
-        },
-        "some_base_property_yaml": {
-          "type": "integer"
-        },
-        "tags": {
-          "patternProperties": {
-            ".*": {
-              "additionalProperties": true,
-              "type": "object"
+        "feeling": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
             }
-          },
-          "type": "object"
+          ]
         },
-        "website": {
+        "age":{
+          "maximum": 120,
+          "exclusiveMaximum": true,
+          "minimum": 18,
+          "exclusiveMinimum": true,
+          "type": "integer"
+        },
+        "email": {
           "type": "string",
-          "format": "uri"
+          "format": "email"
         }
       },
       "additionalProperties": true,

--- a/fixtures/defaults.json
+++ b/fixtures/defaults.json
@@ -28,38 +28,36 @@
         "email"
       ],
       "properties": {
-        "PublicNonExported": {
+        "some_base_property": {
           "type": "integer"
+        },
+        "some_base_property_yaml": {
+          "type": "integer"
+        },
+        "grand": {
+          "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
+          "$ref": "#\/definitions\/GrandfatherType"
         },
         "SomeUntaggedBaseProperty": {
           "type": "boolean"
         },
-        "TestFlag": {
-          "type": "boolean"
-        },
-        "age": {
-          "maximum": 120,
-          "minimum": 18,
-          "exclusiveMaximum": true,
-          "exclusiveMinimum": true,
+        "PublicNonExported": {
           "type": "integer"
         },
-        "email": {
-          "type": "string",
-          "format": "email"
+        "id": {
+          "type": "integer"
         },
-        "birth_date": {
+        "name": {
+          "maxLength": 20,
+          "minLength": 1,
+          "pattern": ".*",
           "type": "string",
-          "format": "date-time"
-        },
-        "feeling": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "integer"
-            }
+          "title": "the name",
+          "description": "this is a property",
+          "default": "alex",
+          "examples": [
+            "joe",
+            "lucy"
           ]
         },
         "friends": {
@@ -69,25 +67,25 @@
           "type": "array",
           "description": "list of IDs, omitted when empty"
         },
-        "grand": {
-          "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
-          "$ref": "#\/definitions\/GrandfatherType"
+        "tags": {
+          "patternProperties": {
+            ".*": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "type": "object"
         },
-        "id": {
-          "type": "integer"
+        "TestFlag": {
+          "type": "boolean"
         },
-        "name": {
+        "birth_date": {
           "type": "string",
-          "maxLength": 20,
-          "minLength": 1,
-          "pattern": ".*",
-          "title": "the name",
-          "description": "this is a property",
-          "default": "alex",
-          "examples": [
-            "joe",
-            "lucy"
-          ]
+          "format": "date-time"
+        },
+        "website": {
+          "type": "string",
+          "format": "uri"
         },
         "network_address": {
           "type": "string",
@@ -99,24 +97,26 @@
             "binaryEncoding": "base64"
           }
         },
-        "some_base_property": {
-          "type": "integer"
-        },
-        "some_base_property_yaml": {
-          "type": "integer"
-        },
-        "tags": {
-          "patternProperties": {
-            ".*": {
-              "additionalProperties": true,
-              "type": "object"
+        "feeling": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
             }
-          },
-          "type": "object"
+          ]
         },
-        "website": {
+        "age": {
+          "maximum": 120,
+          "exclusiveMaximum": true,
+          "minimum": 18,
+          "exclusiveMinimum": true,
+          "type": "integer"
+        },
+        "email": {
           "type": "string",
-          "format": "uri"
+          "format": "email"
         }
       },
       "additionalProperties": false,

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -13,39 +13,37 @@
     "email"
   ],
   "properties": {
-    "PublicNonExported": {
+    "some_base_property": {
       "type": "integer"
+    },
+    "some_base_property_yaml": {
+      "type": "integer"
+    },
+    "grand": {
+      "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
+      "$ref": "#\/definitions\/GrandfatherType"
     },
     "SomeUntaggedBaseProperty": {
       "type": "boolean"
     },
-    "TestFlag": {
-      "type": "boolean"
-    },
-    "age":{
-      "maximum": 120,
-      "minimum": 18,
-      "exclusiveMaximum": true,
-      "exclusiveMinimum": true,
+    "PublicNonExported": {
       "type": "integer"
     },
-    "email": {
-      "type": "string",
-      "format": "email"
+    "id": {
+      "type": "integer"
     },
-    "birth_date": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "feeling": {
-      "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "integer"
-        }
-      ]
+    "name": {
+        "maxLength": 20,
+        "minLength": 1,
+        "pattern": ".*",
+        "type": "string",
+        "title": "the name",
+        "description": "this is a property",
+        "default": "alex",
+        "examples": [
+          "joe",
+          "lucy"
+        ]
     },
     "friends": {
       "items": {
@@ -54,25 +52,25 @@
       "type": "array",
       "description": "list of IDs, omitted when empty"
     },
-    "grand": {
-      "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
-      "$ref": "#\/definitions\/GrandfatherType"
+    "tags": {
+      "patternProperties": {
+        ".*": {
+          "additionalProperties": true,
+          "type": "object"
+        }
+      },
+      "type": "object"
     },
-    "id": {
-      "type": "integer"
+    "TestFlag": {
+      "type": "boolean"
     },
-    "name": {
-        "type": "string",
-        "maxLength": 20,
-        "minLength": 1,
-        "pattern": ".*",
-        "title": "the name",
-        "description": "this is a property",
-        "default": "alex",
-        "examples": [
-          "joe",
-          "lucy"
-        ]
+    "birth_date": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "website": {
+      "type": "string",
+      "format": "uri"
     },
     "network_address": {
       "type": "string",
@@ -84,24 +82,26 @@
         "binaryEncoding": "base64"
       }
     },
-    "some_base_property": {
-      "type": "integer"
-    },
-    "some_base_property_yaml": {
-      "type": "integer"
-    },
-    "tags": {
-      "patternProperties": {
-        ".*": {
-          "additionalProperties": true,
-          "type": "object"
+    "feeling": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
         }
-      },
-      "type": "object"
+      ]
     },
-    "website": {
+    "age":{
+      "maximum": 120,
+      "exclusiveMaximum": true,
+      "minimum": 18,
+      "exclusiveMinimum": true,
+      "type": "integer"
+    },
+    "email": {
       "type": "string",
-      "format": "uri"
+      "format": "email"
     }
   },
   "additionalProperties": false,

--- a/fixtures/ignore_type.json
+++ b/fixtures/ignore_type.json
@@ -21,50 +21,21 @@
         "email"
       ],
       "properties": {
-        "PublicNonExported": {
+        "some_base_property": {
           "type": "integer"
         },
-        "SomeUntaggedBaseProperty": {
-          "type": "boolean"
-        },
-        "TestFlag": {
-          "type": "boolean"
-        },
-        "age": {
-          "maximum": 120,
-          "exclusiveMaximum": true,
-          "minimum": 18,
-          "exclusiveMinimum": true,
+        "some_base_property_yaml": {
           "type": "integer"
-        },
-        "birth_date": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "email": {
-          "type": "string",
-          "format": "email"
-        },
-        "feeling": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "integer"
-            }
-          ]
-        },
-        "friends": {
-          "items": {
-            "type": "integer"
-          },
-          "type": "array",
-          "description": "list of IDs, omitted when empty"
         },
         "grand": {
           "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
           "$ref": "#\/definitions\/GrandfatherType"
+        },
+        "SomeUntaggedBaseProperty": {
+          "type": "boolean"
+        },
+        "PublicNonExported": {
+          "type": "integer"
         },
         "id": {
           "type": "integer"
@@ -82,21 +53,12 @@
             "lucy"
           ]
         },
-        "network_address": {
-          "type": "string",
-          "format": "ipv4"
-        },
-        "photo": {
-          "type": "string",
-          "media": {
-            "binaryEncoding": "base64"
-          }
-        },
-        "some_base_property": {
-          "type": "integer"
-        },
-        "some_base_property_yaml": {
-          "type": "integer"
+        "friends": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array",
+          "description": "list of IDs, omitted when empty"
         },
         "tags": {
           "patternProperties": {
@@ -107,9 +69,47 @@
           },
           "type": "object"
         },
+        "TestFlag": {
+          "type": "boolean"
+        },
+        "birth_date": {
+          "type": "string",
+          "format": "date-time"
+        },
         "website": {
           "type": "string",
           "format": "uri"
+        },
+        "network_address": {
+          "type": "string",
+          "format": "ipv4"
+        },
+        "photo": {
+          "type": "string",
+          "media": {
+            "binaryEncoding": "base64"
+          }
+        },
+        "feeling": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "age": {
+          "maximum": 120,
+          "exclusiveMaximum": true,
+          "minimum": 18,
+          "exclusiveMinimum": true,
+          "type": "integer"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
         }
       },
       "additionalProperties": false,

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -22,38 +22,36 @@
         "photo"
       ],
       "properties": {
-        "PublicNonExported": {
+        "some_base_property": {
           "type": "integer"
+        },
+        "some_base_property_yaml": {
+          "type": "integer"
+        },
+        "grand": {
+          "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
+          "$ref": "#\/definitions\/GrandfatherType"
         },
         "SomeUntaggedBaseProperty": {
           "type": "boolean"
         },
-        "TestFlag": {
-          "type": "boolean"
-        },
-        "age":{
-          "maximum": 120,
-          "minimum": 18,
-          "exclusiveMaximum": true,
-          "exclusiveMinimum": true,
+        "PublicNonExported": {
           "type": "integer"
         },
-        "email": {
-          "type": "string",
-          "format": "email"
+        "id": {
+          "type": "integer"
         },
-        "birth_date": {
+        "name": {
+          "maxLength": 20,
+          "minLength": 1,
+          "pattern": ".*",
           "type": "string",
-          "format": "date-time"
-        },
-        "feeling": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "integer"
-            }
+          "title": "the name",
+          "description": "this is a property",
+          "default": "alex",
+          "examples": [
+            "joe",
+            "lucy"
           ]
         },
         "friends": {
@@ -63,25 +61,25 @@
           "type": "array",
           "description": "list of IDs, omitted when empty"
         },
-        "grand": {
-          "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
-          "$ref": "#\/definitions\/GrandfatherType"
+        "tags": {
+          "patternProperties": {
+            ".*": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "type": "object"
         },
-        "id": {
-          "type": "integer"
+        "TestFlag": {
+          "type": "boolean"
         },
-        "name": {
+        "birth_date": {
           "type": "string",
-          "maxLength": 20,
-          "minLength": 1,
-          "pattern": ".*",
-          "title": "the name",
-          "description": "this is a property",
-          "default": "alex",
-          "examples": [
-            "joe",
-            "lucy"
-          ]
+          "format": "date-time"
+        },
+        "website": {
+          "type": "string",
+          "format": "uri"
         },
         "network_address": {
           "type": "string",
@@ -93,24 +91,26 @@
             "binaryEncoding": "base64"
           }
         },
-        "some_base_property": {
-          "type": "integer"
-        },
-        "some_base_property_yaml": {
-          "type": "integer"
-        },
-        "tags": {
-          "patternProperties": {
-            ".*": {
-              "additionalProperties": true,
-              "type": "object"
+        "feeling": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
             }
-          },
-          "type": "object"
+          ]
         },
-        "website": {
+        "age":{
+          "maximum": 120,
+          "exclusiveMaximum": true,
+          "minimum": 18,
+          "exclusiveMinimum": true,
+          "type": "integer"
+        },
+        "email": {
           "type": "string",
-          "format": "uri"
+          "format": "email"
         }
       },
       "additionalProperties": false,

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/alecthomas/jsonschema
 
 go 1.12
 
-require github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709
+require (
+	github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0
+	github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 h1:i462o439ZjprVSFSZLZxcsoAe592sZB1rci2Z8j4wdk=
+github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709 h1:Ko2LQMrRU+Oy/+EDBwX7eZ2jp3C47eDBB8EIhKTun+I=
+github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/reflect.go
+++ b/reflect.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/iancoleman/orderedmap"
 )
 
 // Version is the JSON Schema version.
@@ -34,33 +36,33 @@ type Type struct {
 	Version string `json:"$schema,omitempty"` // section 6.1
 	Ref     string `json:"$ref,omitempty"`    // section 7
 	// RFC draft-wright-json-schema-validation-00, section 5
-	MultipleOf           int              `json:"multipleOf,omitempty"`           // section 5.1
-	Maximum              int              `json:"maximum,omitempty"`              // section 5.2
-	ExclusiveMaximum     bool             `json:"exclusiveMaximum,omitempty"`     // section 5.3
-	Minimum              int              `json:"minimum,omitempty"`              // section 5.4
-	ExclusiveMinimum     bool             `json:"exclusiveMinimum,omitempty"`     // section 5.5
-	MaxLength            int              `json:"maxLength,omitempty"`            // section 5.6
-	MinLength            int              `json:"minLength,omitempty"`            // section 5.7
-	Pattern              string           `json:"pattern,omitempty"`              // section 5.8
-	AdditionalItems      *Type            `json:"additionalItems,omitempty"`      // section 5.9
-	Items                *Type            `json:"items,omitempty"`                // section 5.9
-	MaxItems             int              `json:"maxItems,omitempty"`             // section 5.10
-	MinItems             int              `json:"minItems,omitempty"`             // section 5.11
-	UniqueItems          bool             `json:"uniqueItems,omitempty"`          // section 5.12
-	MaxProperties        int              `json:"maxProperties,omitempty"`        // section 5.13
-	MinProperties        int              `json:"minProperties,omitempty"`        // section 5.14
-	Required             []string         `json:"required,omitempty"`             // section 5.15
-	Properties           map[string]*Type `json:"properties,omitempty"`           // section 5.16
-	PatternProperties    map[string]*Type `json:"patternProperties,omitempty"`    // section 5.17
-	AdditionalProperties json.RawMessage  `json:"additionalProperties,omitempty"` // section 5.18
-	Dependencies         map[string]*Type `json:"dependencies,omitempty"`         // section 5.19
-	Enum                 []interface{}    `json:"enum,omitempty"`                 // section 5.20
-	Type                 string           `json:"type,omitempty"`                 // section 5.21
-	AllOf                []*Type          `json:"allOf,omitempty"`                // section 5.22
-	AnyOf                []*Type          `json:"anyOf,omitempty"`                // section 5.23
-	OneOf                []*Type          `json:"oneOf,omitempty"`                // section 5.24
-	Not                  *Type            `json:"not,omitempty"`                  // section 5.25
-	Definitions          Definitions      `json:"definitions,omitempty"`          // section 5.26
+	MultipleOf           int                    `json:"multipleOf,omitempty"`           // section 5.1
+	Maximum              int                    `json:"maximum,omitempty"`              // section 5.2
+	ExclusiveMaximum     bool                   `json:"exclusiveMaximum,omitempty"`     // section 5.3
+	Minimum              int                    `json:"minimum,omitempty"`              // section 5.4
+	ExclusiveMinimum     bool                   `json:"exclusiveMinimum,omitempty"`     // section 5.5
+	MaxLength            int                    `json:"maxLength,omitempty"`            // section 5.6
+	MinLength            int                    `json:"minLength,omitempty"`            // section 5.7
+	Pattern              string                 `json:"pattern,omitempty"`              // section 5.8
+	AdditionalItems      *Type                  `json:"additionalItems,omitempty"`      // section 5.9
+	Items                *Type                  `json:"items,omitempty"`                // section 5.9
+	MaxItems             int                    `json:"maxItems,omitempty"`             // section 5.10
+	MinItems             int                    `json:"minItems,omitempty"`             // section 5.11
+	UniqueItems          bool                   `json:"uniqueItems,omitempty"`          // section 5.12
+	MaxProperties        int                    `json:"maxProperties,omitempty"`        // section 5.13
+	MinProperties        int                    `json:"minProperties,omitempty"`        // section 5.14
+	Required             []string               `json:"required,omitempty"`             // section 5.15
+	Properties           *orderedmap.OrderedMap `json:"properties,omitempty"`           // section 5.16
+	PatternProperties    map[string]*Type       `json:"patternProperties,omitempty"`    // section 5.17
+	AdditionalProperties json.RawMessage        `json:"additionalProperties,omitempty"` // section 5.18
+	Dependencies         map[string]*Type       `json:"dependencies,omitempty"`         // section 5.19
+	Enum                 []interface{}          `json:"enum,omitempty"`                 // section 5.20
+	Type                 string                 `json:"type,omitempty"`                 // section 5.21
+	AllOf                []*Type                `json:"allOf,omitempty"`                // section 5.22
+	AnyOf                []*Type                `json:"anyOf,omitempty"`                // section 5.23
+	OneOf                []*Type                `json:"oneOf,omitempty"`                // section 5.24
+	Not                  *Type                  `json:"not,omitempty"`                  // section 5.25
+	Definitions          Definitions            `json:"definitions,omitempty"`          // section 5.26
 	// RFC draft-wright-json-schema-validation-00, section 6, 7
 	Title       string        `json:"title,omitempty"`       // section 6.1
 	Description string        `json:"description,omitempty"` // section 6.1
@@ -121,7 +123,7 @@ func (r *Reflector) ReflectFromType(t reflect.Type) *Schema {
 		st := &Type{
 			Version:              Version,
 			Type:                 "object",
-			Properties:           map[string]*Type{},
+			Properties:           orderedmap.New(),
 			AdditionalProperties: []byte("false"),
 		}
 		if r.AllowAdditionalProperties {
@@ -263,7 +265,7 @@ func (r *Reflector) reflectStruct(definitions Definitions, t reflect.Type) *Type
 		if reflect.TypeOf(ignored) == t {
 			st := &Type{
 				Type:                 "object",
-				Properties:           map[string]*Type{},
+				Properties:           orderedmap.New(),
 				AdditionalProperties: []byte("true"),
 			}
 			definitions[t.Name()] = st
@@ -277,7 +279,7 @@ func (r *Reflector) reflectStruct(definitions Definitions, t reflect.Type) *Type
 	}
 	st := &Type{
 		Type:                 "object",
-		Properties:           map[string]*Type{},
+		Properties:           orderedmap.New(),
 		AdditionalProperties: []byte("false"),
 	}
 	if r.AllowAdditionalProperties {
@@ -313,7 +315,7 @@ func (r *Reflector) reflectStructFields(st *Type, definitions Definitions, t ref
 
 		property := r.reflectTypeToSchema(definitions, f.Type)
 		property.structKeywordsFromTags(f)
-		st.Properties[name] = property
+		st.Properties.Set(name, property)
 		if required {
 			st.Required = append(st.Required, name)
 		}


### PR DESCRIPTION
Change `Type.Properties` from `map[string]*Type` to `*orderedmap.OrderedMap` to preserve sequence of struct fields in rendered JSON.

The bulk of the changed code are actually the tests, getting them passing again :)

Closes #50 