### PR TITLE
Extra Fields on Generated Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@
 
 This package can be used to generate [JSON Schemas](http://json-schema.org/latest/json-schema-validation.html) from Go types through reflection.
 
-It supports arbitrarily complex types, including `interface{}`, maps, slices, etc.
-And it also supports json-schema features such as minLength, maxLength, pattern, format and etc.
+- Supports arbitrarily complex types, including `interface{}`, maps, slices, etc.
+- Supports json-schema features such as minLength, maxLength, pattern, format, etc.
+- Supports custom property fields via the `jsonschema_extras` struct tag.
+
 ## Example
 
 The following Go type:
@@ -18,7 +20,7 @@ type TestUser struct {
   ID            int                    `json:"id"`
   Name          string                 `json:"name" jsonschema:"title=the name,description=The name of a friend,example=joe,example=lucy,default=alex"`
   Friends       []int                  `json:"friends,omitempty" jsonschema_description:"The list of IDs, omitted when empty"`
-  Tags          map[string]interface{} `json:"tags,omitempty"`
+  Tags          map[string]interface{} `json:"tags,omitempty" jsonschema_extras:"a=b,foo=bar"`
   BirthDate     time.Time              `json:"birth_date,omitempty" jsonschema:"oneof_required=date"`
   YearOfBirth   string                 `json:"year_of_birth,omitempty" jsonschema:"oneof_required=year"`
   Metadata      interface{}            `json:"metadata,omitempty" jsonschema:"oneof_type=string;array"`
@@ -80,7 +82,9 @@ jsonschema.Reflect(&TestUser{})
               "type": "object",
               "additionalProperties": true
             }
-          }
+          },
+          "a": "b",
+          "foo": "bar"
         }
       },
       "additionalProperties": false,

--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -117,6 +117,11 @@
         "email": {
           "type": "string",
           "format": "email"
+        },
+        "Baz": {
+          "type": "string",
+          "foo": "bar",
+          "hello": "world"
         }
       },
       "additionalProperties": true,

--- a/fixtures/defaults.json
+++ b/fixtures/defaults.json
@@ -117,6 +117,11 @@
         "email": {
           "type": "string",
           "format": "email"
+        },
+        "Baz": {
+          "type": "string",
+          "foo": "bar",
+          "hello": "world"
         }
       },
       "additionalProperties": false,

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -10,7 +10,8 @@
     "name",
     "TestFlag",
     "age",
-    "email"
+    "email",
+    "Baz"
   ],
   "properties": {
     "some_base_property": {
@@ -102,6 +103,11 @@
     "email": {
       "type": "string",
       "format": "email"
+    },
+    "Baz": {
+      "type": "string",
+      "foo": "bar",
+      "hello": "world"
     }
   },
   "additionalProperties": false,

--- a/fixtures/ignore_type.json
+++ b/fixtures/ignore_type.json
@@ -110,6 +110,11 @@
         "email": {
           "type": "string",
           "format": "email"
+        },
+        "Baz": {
+          "type": "string",
+          "foo": "bar",
+          "hello": "world"
         }
       },
       "additionalProperties": false,

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -111,6 +111,11 @@
         "email": {
           "type": "string",
           "format": "email"
+        },
+        "Baz": {
+          "type": "string",
+          "foo": "bar",
+          "hello": "world"
         }
       },
       "additionalProperties": false,

--- a/reflect.go
+++ b/reflect.go
@@ -73,7 +73,7 @@ type Type struct {
 	Media          *Type  `json:"media,omitempty"`          // section 4.3
 	BinaryEncoding string `json:"binaryEncoding,omitempty"` // section 4.3
 
-	Extras map[string]interface{} `json:"-"`
+	Extras map[string]interface{} `json:"-" `
 }
 
 // Reflect reflects to Schema from a value using the default Reflector

--- a/reflect.go
+++ b/reflect.go
@@ -73,7 +73,7 @@ type Type struct {
 	Media          *Type  `json:"media,omitempty"`          // section 4.3
 	BinaryEncoding string `json:"binaryEncoding,omitempty"` // section 4.3
 
-	Extras map[string]interface{} `json:"-" `
+	Extras map[string]interface{} `json:"-"`
 }
 
 // Reflect reflects to Schema from a value using the default Reflector

--- a/reflect.go
+++ b/reflect.go
@@ -72,6 +72,8 @@ type Type struct {
 	// RFC draft-wright-json-schema-hyperschema-00, section 4
 	Media          *Type  `json:"media,omitempty"`          // section 4.3
 	BinaryEncoding string `json:"binaryEncoding,omitempty"` // section 4.3
+
+	Extras map[string]interface{} `json:"-"`
 }
 
 // Reflect reflects to Schema from a value using the default Reflector
@@ -337,6 +339,8 @@ func (t *Type) structKeywordsFromTags(f reflect.StructField, parentType *Type, p
 	case "array":
 		t.arrayKeywords(tags)
 	}
+	extras := strings.Split(f.Tag.Get("jsonschema_extras"), ",")
+	t.extraKeywords(extras)
 }
 
 // read struct tags for generic keyworks
@@ -487,6 +491,22 @@ func (t *Type) arrayKeywords(tags []string) {
 	}
 }
 
+func (t *Type) extraKeywords(tags []string) {
+	for _, tag := range tags {
+		nameValue := strings.Split(tag, "=")
+		if len(nameValue) == 2 {
+			t.setExtra(nameValue[0], nameValue[1])
+		}
+	}
+}
+
+func (t *Type) setExtra(key, val string) {
+	if t.Extras == nil {
+		t.Extras = map[string]interface{}{}
+	}
+	t.Extras[key] = val
+}
+
 func requiredFromJSONTags(tags []string) bool {
 	if ignoredByJSONTags(tags) {
 		return false
@@ -559,4 +579,25 @@ func (r *Reflector) reflectFieldName(f reflect.StructField) (string, bool, bool)
 	}
 
 	return name, exist, required
+}
+
+func (t Type) MarshalJSON() ([]byte, error) {
+	type Type_ Type
+	b, err := json.Marshal(Type_(t))
+	if err != nil {
+		return nil, err
+	}
+	if t.Extras == nil || len(t.Extras) == 0 {
+		return b, nil
+	}
+	m, err := json.Marshal(t.Extras)
+	if err != nil {
+		return nil, err
+	}
+	if len(b) == 2 {
+		return m, nil
+	} else {
+		b[len(b)-1] = ','
+		return append(b, m[1:]...), nil
+	}
 }

--- a/reflect.go
+++ b/reflect.go
@@ -581,9 +581,9 @@ func (r *Reflector) reflectFieldName(f reflect.StructField) (string, bool, bool)
 	return name, exist, required
 }
 
-func (t Type) MarshalJSON() ([]byte, error) {
+func (t *Type) MarshalJSON() ([]byte, error) {
 	type Type_ Type
-	b, err := json.Marshal(Type_(t))
+	b, err := json.Marshal((*Type_)(t))
 	if err != nil {
 		return nil, err
 	}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -74,6 +74,9 @@ type TestUser struct {
 	Feeling ProtoEnum `json:"feeling,omitempty"`
 	Age     int       `json:"age" jsonschema:"minimum=18,maximum=120,exclusiveMaximum=true,exclusiveMinimum=true"`
 	Email   string    `json:"email" jsonschema:"format=email"`
+
+	// Test for "extras" support
+	Baz string `jsonschema_extras:"foo=bar,hello=world"`
 }
 
 type CustomTime time.Time


### PR DESCRIPTION
As per #52 this PR adds support for extra fields on generated schema types, with the struct tag `jsonschema_extras`.  It also includes a test of this functionality.  Sample:

```go
type Apple struct { 
    Banana string `jsonschema_extras:"widget=mango"`
}

jsonschema.Reflect(Apple{})
```
```json
{
  "properties": {
    "Banana": {
      "type": "string",
      "widget": "mango"
    }
  }
}
```