### PR TITLE
Fix Schema Marshaling

### DIFF
--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -25,7 +25,8 @@
         "name",
         "TestFlag",
         "age",
-        "email"
+        "email",
+        "Baz"
       ],
       "properties": {
         "some_base_property": {

--- a/fixtures/defaults.json
+++ b/fixtures/defaults.json
@@ -25,7 +25,8 @@
         "name",
         "TestFlag",
         "age",
-        "email"
+        "email",
+        "Baz"
       ],
       "properties": {
         "some_base_property": {

--- a/fixtures/ignore_type.json
+++ b/fixtures/ignore_type.json
@@ -18,7 +18,8 @@
         "name",
         "TestFlag",
         "age",
-        "email"
+        "email",
+        "Baz"
       ],
       "properties": {
         "some_base_property": {

--- a/reflect.go
+++ b/reflect.go
@@ -27,7 +27,7 @@ var Version = "http://json-schema.org/draft-04/schema#"
 // RFC draft-wright-json-schema-00, section 4.5
 type Schema struct {
 	*Type
-	Definitions Definitions `json:"definitions,omitempty"`
+	Definitions Definitions
 }
 
 // Type represents a JSON Schema object type.
@@ -579,6 +579,28 @@ func (r *Reflector) reflectFieldName(f reflect.StructField) (string, bool, bool)
 	}
 
 	return name, exist, required
+}
+
+func (s *Schema) MarshalJSON() ([]byte, error) {
+	b, err := json.Marshal(s.Type)
+	if err != nil {
+		return nil, err
+	}
+	if s.Definitions == nil || len(s.Definitions) == 0 {
+		return b, nil
+	}
+	d, err := json.Marshal(struct {
+		Definitions Definitions `json:"definitions,omitempty"`
+	}{s.Definitions})
+	if err != nil {
+		return nil, err
+	}
+	if len(b) == 2 {
+		return d, nil
+	} else {
+		b[len(b)-1] = ','
+		return append(b, d[1:]...), nil
+	}
 }
 
 func (t *Type) MarshalJSON() ([]byte, error) {

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -143,3 +143,15 @@ func TestSchemaGeneration(t *testing.T) {
 		})
 	}
 }
+
+func TestBaselineUnmarshal(t *testing.T) {
+	expectedJSON, err := ioutil.ReadFile("fixtures/defaults.json")
+	require.NoError(t, err)
+
+	reflector := &Reflector{}
+	actualSchema := reflector.Reflect(&TestUser{})
+
+	actualJSON, _ := json.MarshalIndent(actualSchema, "", "  ")
+
+	require.Equal(t, strings.Replace(string(expectedJSON), `\/`, "/", -1), string(actualJSON))
+}


### PR DESCRIPTION
Fixes #56 

This went undetected because the tabular test behavior was to unmarshal JSON into a Schema and then re-marshal it.  To catch this in the future, I'm adding a test that marshals a Schema and compares it directly with the fixture.

First commit is just to add the failing test and show that it fails via CI.  Next commit will fix the issue.