### PR TITLE
Add DoNotReference and FullyQualifyTypeNames

### DIFF
--- a/fixtures/fully_qualified.json
+++ b/fixtures/fully_qualified.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/github.com/alecthomas/jsonschema.TestUser",
+  "definitions": {
+    "github.com/alecthomas/jsonschema.GrandfatherType": {
+      "required": [
+        "family_name"
+      ],
+      "properties": {
+        "family_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "github.com/alecthomas/jsonschema.TestUser": {
+      "required": [
+        "some_base_property",
+        "some_base_property_yaml",
+        "grand",
+        "SomeUntaggedBaseProperty",
+        "PublicNonExported",
+        "id",
+        "name",
+        "TestFlag",
+        "age",
+        "email",
+        "Baz",
+        "color"
+      ],
+      "properties": {
+        "some_base_property": {
+          "type": "integer"
+        },
+        "some_base_property_yaml": {
+          "type": "integer"
+        },
+        "grand": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/github.com/alecthomas/jsonschema.GrandfatherType"
+        },
+        "SomeUntaggedBaseProperty": {
+          "type": "boolean"
+        },
+        "PublicNonExported": {
+          "type": "integer"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "maxLength": 20,
+          "minLength": 1,
+          "pattern": ".*",
+          "type": "string",
+          "title": "the name",
+          "description": "this is a property",
+          "default": "alex",
+          "examples": [
+            "joe",
+            "lucy"
+          ]
+        },
+        "friends": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array",
+          "description": "list of IDs, omitted when empty"
+        },
+        "tags": {
+          "patternProperties": {
+            ".*": {
+              "additionalProperties": true
+            }
+          },
+          "type": "object"
+        },
+        "TestFlag": {
+          "type": "boolean"
+        },
+        "birth_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "website": {
+          "type": "string",
+          "format": "uri"
+        },
+        "network_address": {
+          "type": "string",
+          "format": "ipv4"
+        },
+        "photo": {
+          "type": "string",
+          "media": {
+            "binaryEncoding": "base64"
+          }
+        },
+        "feeling": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "age": {
+          "maximum": 120,
+          "exclusiveMaximum": true,
+          "minimum": 18,
+          "exclusiveMinimum": true,
+          "type": "integer"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "Baz": {
+          "type": "string",
+          "foo": [
+            "bar",
+            "bar1"
+          ],
+          "hello": "world"
+        },
+        "color": {
+          "enum": [
+            "red",
+            "green",
+            "blue"
+          ],
+          "type": "string"
+        },
+        "rank": {
+          "enum": [
+            1,
+            2,
+            3
+          ],
+          "type": "integer"
+        },
+        "mult": {
+          "enum": [
+            1,
+            1.5,
+            2
+          ],
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/fixtures/no_ref_qual_types.json
+++ b/fixtures/no_ref_qual_types.json
@@ -1,0 +1,312 @@
+{
+  "required": [
+    "some_base_property",
+    "some_base_property_yaml",
+    "grand",
+    "SomeUntaggedBaseProperty",
+    "PublicNonExported",
+    "id",
+    "name",
+    "TestFlag",
+    "age",
+    "email",
+    "Baz",
+    "color"
+  ],
+  "properties": {
+    "some_base_property": {
+      "type": "integer"
+    },
+    "some_base_property_yaml": {
+      "type": "integer"
+    },
+    "grand": {
+      "required": [
+        "family_name"
+      ],
+      "properties": {
+        "family_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "SomeUntaggedBaseProperty": {
+      "type": "boolean"
+    },
+    "PublicNonExported": {
+      "type": "integer"
+    },
+    "id": {
+      "type": "integer"
+    },
+    "name": {
+      "maxLength": 20,
+      "minLength": 1,
+      "pattern": ".*",
+      "type": "string",
+      "title": "the name",
+      "description": "this is a property",
+      "default": "alex",
+      "examples": [
+        "joe",
+        "lucy"
+      ]
+    },
+    "friends": {
+      "items": {
+        "type": "integer"
+      },
+      "type": "array",
+      "description": "list of IDs, omitted when empty"
+    },
+    "tags": {
+      "patternProperties": {
+        ".*": {
+          "additionalProperties": true
+        }
+      },
+      "type": "object"
+    },
+    "TestFlag": {
+      "type": "boolean"
+    },
+    "birth_date": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "website": {
+      "type": "string",
+      "format": "uri"
+    },
+    "network_address": {
+      "type": "string",
+      "format": "ipv4"
+    },
+    "photo": {
+      "type": "string",
+      "media": {
+        "binaryEncoding": "base64"
+      }
+    },
+    "feeling": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "age": {
+      "maximum": 120,
+      "exclusiveMaximum": true,
+      "minimum": 18,
+      "exclusiveMinimum": true,
+      "type": "integer"
+    },
+    "email": {
+      "type": "string",
+      "format": "email"
+    },
+    "Baz": {
+      "type": "string",
+      "foo": [
+        "bar",
+        "bar1"
+      ],
+      "hello": "world"
+    },
+    "color": {
+      "enum": [
+        "red",
+        "green",
+        "blue"
+      ],
+      "type": "string"
+    },
+    "rank": {
+      "enum": [
+        1,
+        2,
+        3
+      ],
+      "type": "integer"
+    },
+    "mult": {
+      "enum": [
+        1,
+        1.5,
+        2
+      ],
+      "type": "number"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "definitions": {
+    "github.com/alecthomas/jsonschema.GrandfatherType": {
+      "required": [
+        "family_name"
+      ],
+      "properties": {
+        "family_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "github.com/alecthomas/jsonschema.TestUser": {
+      "required": [
+        "some_base_property",
+        "some_base_property_yaml",
+        "grand",
+        "SomeUntaggedBaseProperty",
+        "PublicNonExported",
+        "id",
+        "name",
+        "TestFlag",
+        "age",
+        "email",
+        "Baz",
+        "color"
+      ],
+      "properties": {
+        "some_base_property": {
+          "type": "integer"
+        },
+        "some_base_property_yaml": {
+          "type": "integer"
+        },
+        "grand": {
+          "required": [
+            "family_name"
+          ],
+          "properties": {
+            "family_name": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        },
+        "SomeUntaggedBaseProperty": {
+          "type": "boolean"
+        },
+        "PublicNonExported": {
+          "type": "integer"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "maxLength": 20,
+          "minLength": 1,
+          "pattern": ".*",
+          "type": "string",
+          "title": "the name",
+          "description": "this is a property",
+          "default": "alex",
+          "examples": [
+            "joe",
+            "lucy"
+          ]
+        },
+        "friends": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array",
+          "description": "list of IDs, omitted when empty"
+        },
+        "tags": {
+          "patternProperties": {
+            ".*": {
+              "additionalProperties": true
+            }
+          },
+          "type": "object"
+        },
+        "TestFlag": {
+          "type": "boolean"
+        },
+        "birth_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "website": {
+          "type": "string",
+          "format": "uri"
+        },
+        "network_address": {
+          "type": "string",
+          "format": "ipv4"
+        },
+        "photo": {
+          "type": "string",
+          "media": {
+            "binaryEncoding": "base64"
+          }
+        },
+        "feeling": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "age": {
+          "maximum": 120,
+          "exclusiveMaximum": true,
+          "minimum": 18,
+          "exclusiveMinimum": true,
+          "type": "integer"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "Baz": {
+          "type": "string",
+          "foo": [
+            "bar",
+            "bar1"
+          ],
+          "hello": "world"
+        },
+        "color": {
+          "enum": [
+            "red",
+            "green",
+            "blue"
+          ],
+          "type": "string"
+        },
+        "rank": {
+          "enum": [
+            1,
+            2,
+            3
+          ],
+          "type": "integer"
+        },
+        "mult": {
+          "enum": [
+            1,
+            1.5,
+            2
+          ],
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/fixtures/no_reference.json
+++ b/fixtures/no_reference.json
@@ -1,0 +1,312 @@
+{
+  "required": [
+    "some_base_property",
+    "some_base_property_yaml",
+    "grand",
+    "SomeUntaggedBaseProperty",
+    "PublicNonExported",
+    "id",
+    "name",
+    "TestFlag",
+    "age",
+    "email",
+    "Baz",
+    "color"
+  ],
+  "properties": {
+    "some_base_property": {
+      "type": "integer"
+    },
+    "some_base_property_yaml": {
+      "type": "integer"
+    },
+    "grand": {
+      "required": [
+        "family_name"
+      ],
+      "properties": {
+        "family_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "SomeUntaggedBaseProperty": {
+      "type": "boolean"
+    },
+    "PublicNonExported": {
+      "type": "integer"
+    },
+    "id": {
+      "type": "integer"
+    },
+    "name": {
+      "maxLength": 20,
+      "minLength": 1,
+      "pattern": ".*",
+      "type": "string",
+      "title": "the name",
+      "description": "this is a property",
+      "default": "alex",
+      "examples": [
+        "joe",
+        "lucy"
+      ]
+    },
+    "friends": {
+      "items": {
+        "type": "integer"
+      },
+      "type": "array",
+      "description": "list of IDs, omitted when empty"
+    },
+    "tags": {
+      "patternProperties": {
+        ".*": {
+          "additionalProperties": true
+        }
+      },
+      "type": "object"
+    },
+    "TestFlag": {
+      "type": "boolean"
+    },
+    "birth_date": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "website": {
+      "type": "string",
+      "format": "uri"
+    },
+    "network_address": {
+      "type": "string",
+      "format": "ipv4"
+    },
+    "photo": {
+      "type": "string",
+      "media": {
+        "binaryEncoding": "base64"
+      }
+    },
+    "feeling": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "age": {
+      "maximum": 120,
+      "exclusiveMaximum": true,
+      "minimum": 18,
+      "exclusiveMinimum": true,
+      "type": "integer"
+    },
+    "email": {
+      "type": "string",
+      "format": "email"
+    },
+    "Baz": {
+      "type": "string",
+      "foo": [
+        "bar",
+        "bar1"
+      ],
+      "hello": "world"
+    },
+    "color": {
+      "enum": [
+        "red",
+        "green",
+        "blue"
+      ],
+      "type": "string"
+    },
+    "rank": {
+      "enum": [
+        1,
+        2,
+        3
+      ],
+      "type": "integer"
+    },
+    "mult": {
+      "enum": [
+        1,
+        1.5,
+        2
+      ],
+      "type": "number"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "definitions": {
+    "GrandfatherType": {
+      "required": [
+        "family_name"
+      ],
+      "properties": {
+        "family_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "TestUser": {
+      "required": [
+        "some_base_property",
+        "some_base_property_yaml",
+        "grand",
+        "SomeUntaggedBaseProperty",
+        "PublicNonExported",
+        "id",
+        "name",
+        "TestFlag",
+        "age",
+        "email",
+        "Baz",
+        "color"
+      ],
+      "properties": {
+        "some_base_property": {
+          "type": "integer"
+        },
+        "some_base_property_yaml": {
+          "type": "integer"
+        },
+        "grand": {
+          "required": [
+            "family_name"
+          ],
+          "properties": {
+            "family_name": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        },
+        "SomeUntaggedBaseProperty": {
+          "type": "boolean"
+        },
+        "PublicNonExported": {
+          "type": "integer"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "maxLength": 20,
+          "minLength": 1,
+          "pattern": ".*",
+          "type": "string",
+          "title": "the name",
+          "description": "this is a property",
+          "default": "alex",
+          "examples": [
+            "joe",
+            "lucy"
+          ]
+        },
+        "friends": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array",
+          "description": "list of IDs, omitted when empty"
+        },
+        "tags": {
+          "patternProperties": {
+            ".*": {
+              "additionalProperties": true
+            }
+          },
+          "type": "object"
+        },
+        "TestFlag": {
+          "type": "boolean"
+        },
+        "birth_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "website": {
+          "type": "string",
+          "format": "uri"
+        },
+        "network_address": {
+          "type": "string",
+          "format": "ipv4"
+        },
+        "photo": {
+          "type": "string",
+          "media": {
+            "binaryEncoding": "base64"
+          }
+        },
+        "feeling": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "age": {
+          "maximum": 120,
+          "exclusiveMaximum": true,
+          "minimum": 18,
+          "exclusiveMinimum": true,
+          "type": "integer"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "Baz": {
+          "type": "string",
+          "foo": [
+            "bar",
+            "bar1"
+          ],
+          "hello": "world"
+        },
+        "color": {
+          "enum": [
+            "red",
+            "green",
+            "blue"
+          ],
+          "type": "string"
+        },
+        "rank": {
+          "enum": [
+            1,
+            2,
+            3
+          ],
+          "type": "integer"
+        },
+        "mult": {
+          "enum": [
+            1,
+            1.5,
+            2
+          ],
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -117,6 +117,9 @@ func TestSchemaGeneration(t *testing.T) {
 		{&TestUser{}, &Reflector{RequiredFromJSONSchemaTags: true}, "fixtures/required_from_jsontags.json"},
 		{&TestUser{}, &Reflector{ExpandedStruct: true}, "fixtures/defaults_expanded_toplevel.json"},
 		{&TestUser{}, &Reflector{IgnoredTypes: []interface{}{GrandfatherType{}}}, "fixtures/ignore_type.json"},
+		{&TestUser{}, &Reflector{DoNotReference: true}, "fixtures/no_reference.json"},
+		{&TestUser{}, &Reflector{FullyQualifyTypeNames: true}, "fixtures/fully_qualified.json"},
+		{&TestUser{}, &Reflector{DoNotReference: true, FullyQualifyTypeNames: true}, "fixtures/no_ref_qual_types.json"},
 		{&CustomTypeField{}, &Reflector{
 			TypeMapper: func(i reflect.Type) *Type {
 				if i == reflect.TypeOf(CustomTime{}) {


### PR DESCRIPTION
This PR adds two options to the Reflector.  I'll quote from the source:

```go
// Do not reference definitions.
// All types are still registered under the "definitions" top-level object,
// but instead of $ref fields in containing types, the entire definition
// of the contained type is inserted.
// This will cause the entire structure of types to be output in one tree.
DoNotReference bool

// Use package paths as well as type names, to avoid conflicts.
// Without this setting, if two packages contain a type with the same name,
// and both are present in a schema, they will conflict and overwrite in
// the definition map and produce bad output.  This is particularly
// noticeable when using DoNotReference.
FullyQualifyTypeNames bool
```

My particular use case was taking the output and piping it into https://github.com/crickford/vue-json-schema-form and these are the changes I had to make for the output to play nicely.

Replaces and closes #70 