### PR TITLE
Add YAMLEmbeddedStructs option

### DIFF
--- a/fixtures/disable_inlining_embedded.json
+++ b/fixtures/disable_inlining_embedded.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "required": [
+    "inner"
+  ],
+  "properties": {
+    "inner": {
+      "required": [
+        "foo"
+      ],
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "definitions": {
+    "Inner": {
+      "required": [
+        "foo"
+      ],
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/reflect.go
+++ b/reflect.go
@@ -101,6 +101,11 @@ type Reflector struct {
 	// default of requiring any key *not* tagged with `json:,omitempty`.
 	RequiredFromJSONSchemaTags bool
 
+	// YAMLEmbeddedStructs will cause the Reflector to generate a schema that does
+	// not inline embedded structs. This should be enabled if the JSON schemas are
+	// used with yaml.Marshal/Unmarshal.
+	YAMLEmbeddedStructs bool
+
 	// ExpandedStruct will cause the toplevel definitions of the schema not
 	// be referenced itself to a definition.
 	ExpandedStruct bool
@@ -618,7 +623,11 @@ func (r *Reflector) reflectFieldName(f reflect.StructField) (string, bool, bool)
 
 	// field anonymous but without json tag should be inherited by current type
 	if f.Anonymous && !exist {
-		name = ""
+		if !r.YAMLEmbeddedStructs {
+			name = ""
+		} else {
+			name = strings.ToLower(name)
+		}
 	}
 
 	return name, exist, required

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -105,6 +105,14 @@ type ChildOneOf struct {
 	Child4 string      `json:"child4" jsonschema:"oneof_required=group1"`
 }
 
+type Outer struct {
+	Inner
+}
+
+type Inner struct {
+	Foo string `yaml:"foo"`
+}
+
 func TestSchemaGeneration(t *testing.T) {
 	tests := []struct {
 		typ       interface{}
@@ -131,6 +139,8 @@ func TestSchemaGeneration(t *testing.T) {
 				return nil
 			},
 		}, "fixtures/custom_type.json"},
+		{&TestUser{}, &Reflector{DoNotReference: true, FullyQualifyTypeNames: true}, "fixtures/no_ref_qual_types.json"},
+		{&Outer{}, &Reflector{ExpandedStruct: true, DoNotReference: true, YAMLEmbeddedStructs: true}, "fixtures/disable_inlining_embedded.json"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
https://github.com/ghodss/yaml treats embedded structs differently to the `json` package. In particular, this struct:

```
type Outer struct {
	Inner
}

type Inner struct {
	Foo string `yaml:"foo"`
}

var myStruct = &Outer{Foo: "bar}
```

Will be ser/de to/from this yaml:

```
inner:
  foo: bar
```

This PR adds an option to support generating JSON schemas that can be used from the `gopkg.in/yaml` package