### PR TITLE
recognize yaml inline

### DIFF
--- a/fixtures/yaml_inline.json
+++ b/fixtures/yaml_inline.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/TestYamlInline",
+  "definitions": {
+    "Inner": {
+      "required": ["foo"],
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "TestYamlInline": {
+      "required": [
+        "Inlined"
+      ],
+      "properties": {
+        "Inlined": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/Inner"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/fixtures/yaml_inline_embed.json
+++ b/fixtures/yaml_inline_embed.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/TestYamlInline",
+  "definitions": {
+    "TestYamlInline": {
+      "required": ["foo"],
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -123,6 +123,10 @@ type TestNullable struct {
 	Child1 string `json:"child1" jsonschema:"nullable"`
 }
 
+type TestYamlInline struct {
+	Inlined Inner `yaml:",inline"`
+}
+
 func TestSchemaGeneration(t *testing.T) {
 	tests := []struct {
 		typ       interface{}
@@ -153,6 +157,8 @@ func TestSchemaGeneration(t *testing.T) {
 		{&Outer{}, &Reflector{ExpandedStruct: true, DoNotReference: true, YAMLEmbeddedStructs: true}, "fixtures/disable_inlining_embedded.json"},
 		{&MinValue{}, &Reflector{}, "fixtures/schema_with_minimum.json"},
 		{&TestNullable{}, &Reflector{}, "fixtures/nullable.json"},
+		{&TestYamlInline{}, &Reflector{YAMLEmbeddedStructs: true}, "fixtures/yaml_inline_embed.json"},
+		{&TestYamlInline{}, &Reflector{}, "fixtures/yaml_inline_embed.json"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
One caveat with this PR is that I wasn't entirely sure of the desired interaction here with https://github.com/alecthomas/jsonschema/commit/7b852d451addeb63f034b93155d535c66fdbc6d7

The `fixtures/yaml_inline.json` is what I originally had when `YAMLEmbeddedStructs` was provided, but this did not seem correct as the `inline` tag is pretty explicit about intent: https://pkg.go.dev/gopkg.in/yaml.v2#Marshal . I can remove that unused fixture if this is agreeable. 