### PR TITLE
Additional fields

### DIFF
--- a/fixtures/custom_additional.json
+++ b/fixtures/custom_additional.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
+  "$ref": "#\/definitions\/GrandfatherType",
+  "definitions": {
+    "GrandfatherType": {
+      "required": [
+        "family_name",
+        "ip_addr"
+      ],
+      "properties": {
+        "family_name": {
+          "type": "string"
+        },
+        "ip_addr": {
+          "type": "string",
+          "format": "ipv4"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -159,6 +159,18 @@ func TestSchemaGeneration(t *testing.T) {
 		{&TestNullable{}, &Reflector{}, "fixtures/nullable.json"},
 		{&TestYamlInline{}, &Reflector{YAMLEmbeddedStructs: true}, "fixtures/yaml_inline_embed.json"},
 		{&TestYamlInline{}, &Reflector{}, "fixtures/yaml_inline_embed.json"},
+		{&GrandfatherType{}, &Reflector{
+			AdditionalFields: func(r reflect.Type) []reflect.StructField {
+				return []reflect.StructField{
+					{
+						Name:      "Addr",
+						Type:      reflect.TypeOf((*net.IP)(nil)).Elem(),
+						Tag:       "json:\"ip_addr\"",
+						Anonymous: false,
+					},
+				}
+			},
+		}, "fixtures/custom_additional.json"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Adds an `AdditionalFields` config that allows one to add arbitrary `StructField`s to a given type.


Why:
I've encountered a [golang project](https://github.com/prometheus/prometheus/blob/master/discovery/registry.go) which does some custom (Un)MarshallYAML for which it would be hard to capture via `TypeMapper`.

Written on #80 but not dependent (I can rebase without if necessary).