### PR TITLE
Support custom type definitions

### DIFF
--- a/fixtures/compact_date.json
+++ b/fixtures/compact_date.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/CompactDate",
+  "definitions": {
+    "CompactDate": {
+      "pattern": "^[0-9]{4}-[0-1][0-9]$",
+      "type": "string",
+      "title": "Compact Date",
+      "description": "Short date that only includes year and month"
+    }
+  }
+}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -134,6 +134,20 @@ type TestYamlAndJson struct {
 	MiddleName string `yaml:"middle_name,omitempty" json:"MiddleName,omitempty"`
 }
 
+type CompactDate struct {
+	Year  int
+	Month int
+}
+
+func (CompactDate) JSONSchemaType() *Type {
+	return &Type{
+		Type:        "string",
+		Title:       "Compact Date",
+		Description: "Short date that only includes year and month",
+		Pattern:     "^[0-9]{4}-[0-1][0-9]$",
+	}
+}
+
 func TestSchemaGeneration(t *testing.T) {
 	tests := []struct {
 		typ       interface{}
@@ -180,6 +194,7 @@ func TestSchemaGeneration(t *testing.T) {
 		}, "fixtures/custom_additional.json"},
 		{&TestYamlAndJson{}, &Reflector{PreferYAMLSchema: true}, "fixtures/test_yaml_and_json_prefer_yaml.json"},
 		{&TestYamlAndJson{}, &Reflector{}, "fixtures/test_yaml_and_json.json"},
+		{&CompactDate{}, &Reflector{}, "fixtures/compact_date.json"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The aim here is to be able to support custom types without having to manually override definitions from the resulting schema. If the `JSONSchemaType() *jsonschema.Type` method is implemented in a struct, it will be used instead of the automatic struct type definition process.

Examples are provided in the README.md and tests. There is likely to be a more appropriate name for the type method, I'm open to suggestions :-)