### PR TITLE
Support json.RawMessage

### DIFF
--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -28,7 +28,8 @@
         "email",
         "Baz",
         "color",
-        "roles"
+        "roles",
+        "raw"
       ],
       "properties": {
         "some_base_property": {
@@ -190,6 +191,9 @@
             "type": "number"
           },
           "type": "array"
+        },
+        "raw": {
+          "additionalProperties": true
         }
       },
       "additionalProperties": true,

--- a/fixtures/defaults.json
+++ b/fixtures/defaults.json
@@ -28,7 +28,8 @@
         "email",
         "Baz",
         "color",
-        "roles"
+        "roles",
+        "raw"
       ],
       "properties": {
         "some_base_property": {
@@ -190,6 +191,9 @@
             "type": "number"
           },
           "type": "array"
+        },
+        "raw": {
+          "additionalProperties": true
         }
       },
       "additionalProperties": false,

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -13,7 +13,8 @@
     "email",
     "Baz",
     "color",
-    "roles"
+    "roles",
+    "raw"
   ],
   "properties": {
     "some_base_property": {
@@ -175,6 +176,9 @@
         "type": "number"
       },
       "type": "array"
+    },
+    "raw": {
+      "additionalProperties": true
     }
   },
   "additionalProperties": false,

--- a/fixtures/fully_qualified.json
+++ b/fixtures/fully_qualified.json
@@ -28,7 +28,8 @@
         "email",
         "Baz",
         "color",
-        "roles"
+        "roles",
+        "raw"
       ],
       "properties": {
         "some_base_property": {
@@ -190,6 +191,9 @@
             "type": "number"
           },
           "type": "array"
+        },
+        "raw": {
+          "additionalProperties": true
         }
       },
       "additionalProperties": false,

--- a/fixtures/ignore_type.json
+++ b/fixtures/ignore_type.json
@@ -21,7 +21,8 @@
         "email",
         "Baz",
         "color",
-        "roles"
+        "roles",
+        "raw"
       ],
       "properties": {
         "some_base_property": {
@@ -183,6 +184,9 @@
             "type": "number"
           },
           "type": "array"
+        },
+        "raw": {
+          "additionalProperties": true
         }
       },
       "additionalProperties": false,

--- a/fixtures/no_ref_qual_types.json
+++ b/fixtures/no_ref_qual_types.json
@@ -12,7 +12,8 @@
     "email",
     "Baz",
     "color",
-    "roles"
+    "roles",
+    "raw"
   ],
   "properties": {
     "some_base_property": {
@@ -182,6 +183,9 @@
         "type": "number"
       },
       "type": "array"
+    },
+    "raw": {
+      "additionalProperties": true
     }
   },
   "additionalProperties": false,
@@ -213,7 +217,8 @@
         "email",
         "Baz",
         "color",
-        "roles"
+        "roles",
+        "raw"
       ],
       "properties": {
         "some_base_property": {
@@ -383,6 +388,9 @@
             "type": "number"
           },
           "type": "array"
+        },
+        "raw": {
+          "additionalProperties": true
         }
       },
       "additionalProperties": false,

--- a/fixtures/no_reference.json
+++ b/fixtures/no_reference.json
@@ -12,7 +12,8 @@
     "email",
     "Baz",
     "color",
-    "roles"
+    "roles",
+    "raw"
   ],
   "properties": {
     "some_base_property": {
@@ -182,6 +183,9 @@
         "type": "number"
       },
       "type": "array"
+    },
+    "raw": {
+      "additionalProperties": true
     }
   },
   "additionalProperties": false,
@@ -213,7 +217,8 @@
         "email",
         "Baz",
         "color",
-        "roles"
+        "roles",
+        "raw"
       ],
       "properties": {
         "some_base_property": {
@@ -383,6 +388,9 @@
             "type": "number"
           },
           "type": "array"
+        },
+        "raw": {
+          "additionalProperties": true
         }
       },
       "additionalProperties": false,

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -182,6 +182,9 @@
             "type": "number"
           },
           "type": "array"
+        },
+        "raw": {
+          "additionalProperties": true
         }
       },
       "additionalProperties": false,

--- a/reflect.go
+++ b/reflect.go
@@ -207,6 +207,9 @@ var (
 // Byte slices will be encoded as base64
 var byteSliceType = reflect.TypeOf([]byte(nil))
 
+// Except for json.RawMessage
+var rawMessageType = reflect.TypeOf(json.RawMessage{})
+
 // Go code generated from protobuf enum types should fulfil this interface.
 type protoEnum interface {
 	EnumDescriptor() ([]byte, []int)
@@ -278,6 +281,11 @@ func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type)
 
 	case reflect.Slice, reflect.Array:
 		returnType := &Type{}
+		if t == rawMessageType {
+			return &Type{
+				AdditionalProperties: []byte("true"),
+			}
+		}
 		if t.Kind() == reflect.Array {
 			returnType.MinItems = t.Len()
 			returnType.MaxItems = returnType.MinItems

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -88,6 +88,9 @@ type TestUser struct {
 	Roles      []string  `json:"roles" jsonschema:"enum=admin,enum=moderator,enum=user"`
 	Priorities []int     `json:"priorities,omitempty" jsonschema:"enum=-1,enum=0,enum=1,enun=2"`
 	Offsets    []float64 `json:"offsets,omitempty" jsonschema:"enum=1.570796,enum=3.141592,enum=6.283185"`
+
+	// Test for raw JSON
+	Raw json.RawMessage `json:"raw"`
 }
 
 type CustomTime time.Time


### PR DESCRIPTION
RawMessage values can represent any JSON value but were previously
represented as binary data [1] in the schema. With this patch they are
represented properly [2].

[1]: `{"type": "string", "media": {"binaryEncoding": "base64"}}`
[2]: `{"additionalProperties": true}`