### PR TITLE
feat(array): add enum support for array property types

### DIFF
--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -27,7 +27,8 @@
         "age",
         "email",
         "Baz",
-        "color"
+        "color",
+        "roles"
       ],
       "properties": {
         "some_base_property": {
@@ -114,7 +115,7 @@
             }
           ]
         },
-        "age":{
+        "age": {
           "maximum": 120,
           "exclusiveMaximum": true,
           "minimum": 18,
@@ -156,6 +157,39 @@
             2
           ],
           "type": "number"
+        },
+        "roles": {
+          "items": {
+            "enum": [
+              "admin",
+              "moderator",
+              "user"
+            ],
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "priorities": {
+          "items": {
+            "enum": [
+              -1,
+              0,
+              1
+            ],
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "offsets": {
+          "items": {
+            "enum": [
+              1.570796,
+              3.141592,
+              6.283185
+            ],
+            "type": "number"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": true,

--- a/fixtures/defaults.json
+++ b/fixtures/defaults.json
@@ -27,7 +27,8 @@
         "age",
         "email",
         "Baz",
-        "color"
+        "color",
+        "roles"
       ],
       "properties": {
         "some_base_property": {
@@ -156,6 +157,39 @@
             2
           ],
           "type": "number"
+        },
+        "roles": {
+          "items": {
+            "enum": [
+              "admin",
+              "moderator",
+              "user"
+            ],
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "priorities": {
+          "items": {
+            "enum": [
+              -1,
+              0,
+              1
+            ],
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "offsets": {
+          "items": {
+            "enum": [
+              1.570796,
+              3.141592,
+              6.283185
+            ],
+            "type": "number"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -12,7 +12,8 @@
     "age",
     "email",
     "Baz",
-    "color"
+    "color",
+    "roles"
   ],
   "properties": {
     "some_base_property": {
@@ -35,17 +36,17 @@
       "type": "integer"
     },
     "name": {
-        "maxLength": 20,
-        "minLength": 1,
-        "pattern": ".*",
-        "type": "string",
-        "title": "the name",
-        "description": "this is a property",
-        "default": "alex",
-        "examples": [
-          "joe",
-          "lucy"
-        ]
+      "maxLength": 20,
+      "minLength": 1,
+      "pattern": ".*",
+      "type": "string",
+      "title": "the name",
+      "description": "this is a property",
+      "default": "alex",
+      "examples": [
+        "joe",
+        "lucy"
+      ]
     },
     "friends": {
       "items": {
@@ -99,7 +100,7 @@
         }
       ]
     },
-    "age":{
+    "age": {
       "maximum": 120,
       "exclusiveMaximum": true,
       "minimum": 18,
@@ -112,10 +113,10 @@
     },
     "Baz": {
       "type": "string",
-       "foo": [
-          "bar",
-          "bar1"
-        ],
+      "foo": [
+        "bar",
+        "bar1"
+      ],
       "hello": "world"
     },
     "color": {
@@ -141,6 +142,39 @@
         2.0
       ],
       "type": "number"
+    },
+    "roles": {
+      "items": {
+        "enum": [
+          "admin",
+          "moderator",
+          "user"
+        ],
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "priorities": {
+      "items": {
+        "enum": [
+          -1,
+          0,
+          1
+        ],
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "offsets": {
+      "items": {
+        "enum": [
+          1.570796,
+          3.141592,
+          6.283185
+        ],
+        "type": "number"
+      },
+      "type": "array"
     }
   },
   "additionalProperties": false,

--- a/fixtures/fully_qualified.json
+++ b/fixtures/fully_qualified.json
@@ -27,7 +27,8 @@
         "age",
         "email",
         "Baz",
-        "color"
+        "color",
+        "roles"
       ],
       "properties": {
         "some_base_property": {
@@ -156,6 +157,39 @@
             2
           ],
           "type": "number"
+        },
+        "roles": {
+          "items": {
+            "enum": [
+              "admin",
+              "moderator",
+              "user"
+            ],
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "priorities": {
+          "items": {
+            "enum": [
+              -1,
+              0,
+              1
+            ],
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "offsets": {
+          "items": {
+            "enum": [
+              1.570796,
+              3.141592,
+              6.283185
+            ],
+            "type": "number"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,

--- a/fixtures/ignore_type.json
+++ b/fixtures/ignore_type.json
@@ -20,7 +20,8 @@
         "age",
         "email",
         "Baz",
-        "color"
+        "color",
+        "roles"
       ],
       "properties": {
         "some_base_property": {
@@ -149,6 +150,39 @@
             2
           ],
           "type": "number"
+        },
+        "roles": {
+          "items": {
+            "enum": [
+              "admin",
+              "moderator",
+              "user"
+            ],
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "priorities": {
+          "items": {
+            "enum": [
+              -1,
+              0,
+              1
+            ],
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "offsets": {
+          "items": {
+            "enum": [
+              1.570796,
+              3.141592,
+              6.283185
+            ],
+            "type": "number"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,

--- a/fixtures/no_ref_qual_types.json
+++ b/fixtures/no_ref_qual_types.json
@@ -11,7 +11,8 @@
     "age",
     "email",
     "Baz",
-    "color"
+    "color",
+    "roles"
   ],
   "properties": {
     "some_base_property": {
@@ -148,6 +149,39 @@
         2
       ],
       "type": "number"
+    },
+    "roles": {
+      "items": {
+        "enum": [
+          "admin",
+          "moderator",
+          "user"
+        ],
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "priorities": {
+      "items": {
+        "enum": [
+          -1,
+          0,
+          1
+        ],
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "offsets": {
+      "items": {
+        "enum": [
+          1.570796,
+          3.141592,
+          6.283185
+        ],
+        "type": "number"
+      },
+      "type": "array"
     }
   },
   "additionalProperties": false,
@@ -178,7 +212,8 @@
         "age",
         "email",
         "Baz",
-        "color"
+        "color",
+        "roles"
       ],
       "properties": {
         "some_base_property": {
@@ -315,6 +350,39 @@
             2
           ],
           "type": "number"
+        },
+        "roles": {
+          "items": {
+            "enum": [
+              "admin",
+              "moderator",
+              "user"
+            ],
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "priorities": {
+          "items": {
+            "enum": [
+              -1,
+              0,
+              1
+            ],
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "offsets": {
+          "items": {
+            "enum": [
+              1.570796,
+              3.141592,
+              6.283185
+            ],
+            "type": "number"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,

--- a/fixtures/no_reference.json
+++ b/fixtures/no_reference.json
@@ -11,7 +11,8 @@
     "age",
     "email",
     "Baz",
-    "color"
+    "color",
+    "roles"
   ],
   "properties": {
     "some_base_property": {
@@ -148,6 +149,39 @@
         2
       ],
       "type": "number"
+    },
+    "roles": {
+      "items": {
+        "enum": [
+          "admin",
+          "moderator",
+          "user"
+        ],
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "priorities": {
+      "items": {
+        "enum": [
+          -1,
+          0,
+          1
+        ],
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "offsets": {
+      "items": {
+        "enum": [
+          1.570796,
+          3.141592,
+          6.283185
+        ],
+        "type": "number"
+      },
+      "type": "array"
     }
   },
   "additionalProperties": false,
@@ -178,7 +212,8 @@
         "age",
         "email",
         "Baz",
-        "color"
+        "color",
+        "roles"
       ],
       "properties": {
         "some_base_property": {
@@ -315,6 +350,39 @@
             2
           ],
           "type": "number"
+        },
+        "roles": {
+          "items": {
+            "enum": [
+              "admin",
+              "moderator",
+              "user"
+            ],
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "priorities": {
+          "items": {
+            "enum": [
+              -1,
+              0,
+              1
+            ],
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "offsets": {
+          "items": {
+            "enum": [
+              1.570796,
+              3.141592,
+              6.283185
+            ],
+            "type": "number"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -107,7 +107,7 @@
             }
           ]
         },
-        "age":{
+        "age": {
           "maximum": 120,
           "exclusiveMaximum": true,
           "minimum": 18,
@@ -149,6 +149,39 @@
             2
           ],
           "type": "number"
+        },
+        "roles": {
+          "items": {
+            "enum": [
+              "admin",
+              "moderator",
+              "user"
+            ],
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "priorities": {
+          "items": {
+            "enum": [
+              -1,
+              0,
+              1
+            ],
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "offsets": {
+          "items": {
+            "enum": [
+              1.570796,
+              3.141592,
+              6.283185
+            ],
+            "type": "number"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,

--- a/reflect.go
+++ b/reflect.go
@@ -570,6 +570,17 @@ func (t *Type) arrayKeywords(tags []string) {
 				t.UniqueItems = true
 			case "default":
 				defaultValues = append(defaultValues, val)
+			case "enum":
+				switch t.Items.Type {
+				case "string":
+					t.Items.Enum = append(t.Items.Enum, val)
+				case "integer":
+					i, _ := strconv.Atoi(val)
+					t.Items.Enum = append(t.Items.Enum, i)
+				case "number":
+					f, _ := strconv.ParseFloat(val, 64)
+					t.Items.Enum = append(t.Items.Enum, f)
+				}
 			}
 		}
 	}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -83,6 +83,11 @@ type TestUser struct {
 	Color      string  `json:"color" jsonschema:"enum=red,enum=green,enum=blue"`
 	Rank       int     `json:"rank,omitempty" jsonschema:"enum=1,enum=2,enum=3"`
 	Multiplier float64 `json:"mult,omitempty" jsonschema:"enum=1.0,enum=1.5,enum=2.0"`
+
+	// Tests for enum tags on slices
+	Roles      []string  `json:"roles" jsonschema:"enum=admin,enum=moderator,enum=user"`
+	Priorities []int     `json:"priorities,omitempty" jsonschema:"enum=-1,enum=0,enum=1,enun=2"`
+	Offsets    []float64 `json:"offsets,omitempty" jsonschema:"enum=1.570796,enum=3.141592,enum=6.283185"`
 }
 
 type CustomTime time.Time


### PR DESCRIPTION
This should resolve #89.

It was a rather quick stab at trying to add the feature, so I'm happy to do any improvements/fixes you may want :)

Personally I'm not super happy with digging down into `t.Items.Enum` directly, as it leaves the door open for a panic if `t.Items` is `nil`. But as far as I can tell, by the time `t.arrayKeywords()` is called, `t.Items` will always be populated with a non-nil value.
