### PR TITLE
Add support for retrieving docs from GetFieldDocString function

### DIFF
--- a/reflect_test.go
+++ b/reflect_test.go
@@ -148,6 +148,28 @@ func (CompactDate) JSONSchemaType() *Type {
 	}
 }
 
+type TestYamlAndJson2 struct {
+	FirstName  string `json:"FirstName" yaml:"first_name"`
+	LastName   string `json:"LastName`
+	Age        uint   `yaml:"age"`
+	MiddleName string `yaml:"middle_name,omitempty" json:"MiddleName,omitempty"`
+}
+
+func (TestYamlAndJson2) GetFieldDocString(fieldName string) string {
+	switch fieldName {
+	case "FirstName":
+		return "test2"
+	case "LastName":
+		return "test3"
+	case "Age":
+		return "test4"
+	case "MiddleName":
+		return "test5"
+	default:
+		return ""
+	}
+}
+
 func TestSchemaGeneration(t *testing.T) {
 	tests := []struct {
 		typ       interface{}
@@ -194,6 +216,7 @@ func TestSchemaGeneration(t *testing.T) {
 		}, "fixtures/custom_additional.json"},
 		{&TestYamlAndJson{}, &Reflector{PreferYAMLSchema: true}, "fixtures/test_yaml_and_json_prefer_yaml.json"},
 		{&TestYamlAndJson{}, &Reflector{}, "fixtures/test_yaml_and_json.json"},
+		{&TestYamlAndJson2{}, &Reflector{}, "fixtures/test_yaml_and_json2.json"},
 		{&CompactDate{}, &Reflector{}, "fixtures/compact_date.json"},
 	}
 


### PR DESCRIPTION
This PR adds support for providing descriptions via a separate `GetFieldDocString` function. Using code generation, we can generate this `GetFieldDocString` based on the comments in the go code. (see https://github.com/amurant/helm-jsonschema-gen).
Providing descriptions via comments that are next to the struct fields is much more user-friendly than providing them via tags.