### PR TITLE
Support read & write only

### DIFF
--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -23,6 +23,7 @@
         "PublicNonExported",
         "id",
         "name",
+        "password",
         "TestFlag",
         "age",
         "email",
@@ -62,7 +63,12 @@
           "examples": [
             "joe",
             "lucy"
-          ]
+          ],
+          "readOnly": true
+        },
+        "password": {
+          "type": "string",
+          "writeOnly": true
         },
         "friends": {
           "items": {

--- a/fixtures/defaults.json
+++ b/fixtures/defaults.json
@@ -23,6 +23,7 @@
         "PublicNonExported",
         "id",
         "name",
+        "password",
         "TestFlag",
         "age",
         "email",
@@ -62,7 +63,12 @@
           "examples": [
             "joe",
             "lucy"
-          ]
+          ],
+          "readOnly": true
+        },
+        "password": {
+          "type": "string",
+          "writeOnly": true
         },
         "friends": {
           "items": {

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -8,6 +8,7 @@
     "PublicNonExported",
     "id",
     "name",
+    "password",
     "TestFlag",
     "age",
     "email",
@@ -47,7 +48,12 @@
       "examples": [
         "joe",
         "lucy"
-      ]
+      ],
+      "readOnly": true
+    },
+    "password": {
+      "type": "string",
+      "writeOnly": true
     },
     "friends": {
       "items": {

--- a/fixtures/fully_qualified.json
+++ b/fixtures/fully_qualified.json
@@ -23,6 +23,7 @@
         "PublicNonExported",
         "id",
         "name",
+        "password",
         "TestFlag",
         "age",
         "email",
@@ -62,7 +63,12 @@
           "examples": [
             "joe",
             "lucy"
-          ]
+          ],
+          "readOnly": true
+        },
+        "password": {
+          "type": "string",
+          "writeOnly": true
         },
         "friends": {
           "items": {

--- a/fixtures/ignore_type.json
+++ b/fixtures/ignore_type.json
@@ -16,6 +16,7 @@
         "PublicNonExported",
         "id",
         "name",
+        "password",
         "TestFlag",
         "age",
         "email",
@@ -55,7 +56,12 @@
           "examples": [
             "joe",
             "lucy"
-          ]
+          ],
+          "readOnly": true
+        },
+        "password": {
+          "type": "string",
+          "writeOnly": true
         },
         "friends": {
           "items": {

--- a/fixtures/no_ref_qual_types.json
+++ b/fixtures/no_ref_qual_types.json
@@ -7,6 +7,7 @@
     "PublicNonExported",
     "id",
     "name",
+    "password",
     "TestFlag",
     "age",
     "email",
@@ -54,7 +55,12 @@
       "examples": [
         "joe",
         "lucy"
-      ]
+      ],
+      "readOnly": true
+    },
+    "password": {
+      "type": "string",
+      "writeOnly": true
     },
     "friends": {
       "items": {
@@ -212,6 +218,7 @@
         "PublicNonExported",
         "id",
         "name",
+        "password",
         "TestFlag",
         "age",
         "email",
@@ -259,7 +266,12 @@
           "examples": [
             "joe",
             "lucy"
-          ]
+          ],
+          "readOnly": true
+        },
+        "password": {
+          "type": "string",
+          "writeOnly": true
         },
         "friends": {
           "items": {

--- a/fixtures/no_reference.json
+++ b/fixtures/no_reference.json
@@ -7,6 +7,7 @@
     "PublicNonExported",
     "id",
     "name",
+    "password",
     "TestFlag",
     "age",
     "email",
@@ -54,7 +55,12 @@
       "examples": [
         "joe",
         "lucy"
-      ]
+      ],
+      "readOnly": true
+    },
+    "password": {
+      "type": "string",
+      "writeOnly": true
     },
     "friends": {
       "items": {
@@ -212,6 +218,7 @@
         "PublicNonExported",
         "id",
         "name",
+        "password",
         "TestFlag",
         "age",
         "email",
@@ -259,7 +266,12 @@
           "examples": [
             "joe",
             "lucy"
-          ]
+          ],
+          "readOnly": true
+        },
+        "password": {
+          "type": "string",
+          "writeOnly": true
         },
         "friends": {
           "items": {

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -53,7 +53,12 @@
           "examples": [
             "joe",
             "lucy"
-          ]
+          ],
+          "readOnly": true
+        },
+        "password": {
+          "type": "string",
+          "writeOnly": true
         },
         "friends": {
           "items": {

--- a/reflect.go
+++ b/reflect.go
@@ -87,6 +87,9 @@ type Type struct {
 	Default     interface{}   `json:"default,omitempty"`     // section 6.2
 	Format      string        `json:"format,omitempty"`      // section 7
 	Examples    []interface{} `json:"examples,omitempty"`    // section 7.4
+	// RFC draft-handrews-json-schema-validation-02, section 9.4
+	ReadOnly  bool `json:"readOnly,omitempty"`
+	WriteOnly bool `json:"writeOnly,omitempty"`
 	// RFC draft-wright-json-schema-hyperschema-00, section 4
 	Media          *Type  `json:"media,omitempty"`          // section 4.3
 	BinaryEncoding string `json:"binaryEncoding,omitempty"` // section 4.3
@@ -530,6 +533,12 @@ func (t *Type) stringKeywords(tags []string) {
 					t.Format = val
 					break
 				}
+			case "readOnly":
+				i, _ := strconv.ParseBool(val)
+				t.ReadOnly = i
+			case "writeOnly":
+				i, _ := strconv.ParseBool(val)
+				t.WriteOnly = i
 			case "default":
 				t.Default = val
 			case "example":

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -54,10 +54,11 @@ type TestUser struct {
 	nonExported
 	MapType
 
-	ID      int                    `json:"id" jsonschema:"required"`
-	Name    string                 `json:"name" jsonschema:"required,minLength=1,maxLength=20,pattern=.*,description=this is a property,title=the name,example=joe,example=lucy,default=alex"`
-	Friends []int                  `json:"friends,omitempty" jsonschema_description:"list of IDs, omitted when empty"`
-	Tags    map[string]interface{} `json:"tags,omitempty"`
+	ID       int                    `json:"id" jsonschema:"required"`
+	Name     string                 `json:"name" jsonschema:"required,minLength=1,maxLength=20,pattern=.*,description=this is a property,title=the name,example=joe,example=lucy,default=alex,readOnly=true"`
+	Password string                 `json:"password" jsonschema:"writeOnly=true"`
+	Friends  []int                  `json:"friends,omitempty" jsonschema_description:"list of IDs, omitted when empty"`
+	Tags     map[string]interface{} `json:"tags,omitempty"`
 
 	TestFlag       bool
 	IgnoredCounter int `json:"-"`


### PR DESCRIPTION
Add `readOnly` and `writeOnly` based on RFC [draft-handrews-json-schema-validation-02 Section 9.4](https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.9.4) 