### PR TITLE
Add support for custom schema types for arrays, slices and maps

### DIFF
--- a/fixtures/custom_map_type.json
+++ b/fixtures/custom_map_type.json
@@ -1,0 +1,33 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"$ref": "#/definitions/CustomMapOuter",
+	"definitions": {
+		"CustomMapOuter": {
+			"type": "object",
+			"required": [
+				"my_map"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"my_map": {
+					"items": {
+						"required": [
+							"key",
+							"value"
+						],
+						"properties": {
+							"key": {
+								"type": "string"
+							},
+							"value": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					"type": "array"
+				}
+			}
+		}
+	}
+}

--- a/fixtures/custom_slice_type.json
+++ b/fixtures/custom_slice_type.json
@@ -1,0 +1,28 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"$ref": "#/definitions/CustomSliceOuter",
+	"definitions": {
+		"CustomSliceOuter": {
+			"type": "object",
+			"required": [
+				"slice"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"slice": {
+					"oneOf": [
+						{
+							"type": "string"
+						},
+						{
+							"items": {
+								"type": "string"
+							},
+							"type": "array"
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/reflect.go
+++ b/reflect.go
@@ -258,6 +258,12 @@ func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type)
 		}
 
 	case reflect.Map:
+		if t.Implements(customStructType) {
+			v := reflect.New(t)
+			o := v.Interface().(customSchemaType)
+			return o.JSONSchemaType()
+		}
+
 		switch t.Key().Kind() {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			rt := &Type{
@@ -281,6 +287,11 @@ func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type)
 
 	case reflect.Slice, reflect.Array:
 		returnType := &Type{}
+		if t.Implements(customStructType) {
+			v := reflect.New(t)
+			o := v.Interface().(customSchemaType)
+			return o.JSONSchemaType()
+		}
 		if t == rawMessageType {
 			return &Type{
 				AdditionalProperties: []byte("true"),


### PR DESCRIPTION
Currently you can only override the JSON schema for structs using the JSONSchemaType function. When this function is provided for custom slice types, then it is ignored. This PR changes the behavior, and also checks if a array, slice or map implements this interface.

An example use case would be for https://github.com/goreleaser/goreleaser/pull/2589, where the data model contains String arrays, that can be just a string if the array should only contain a single item.