### PR TITLE
Adding const to Type

### DIFF
--- a/fixtures/enum_with_constants.json
+++ b/fixtures/enum_with_constants.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/EnumWithConstants",
+    "definitions": {
+        "EnumWithConstants": {
+            "required": [
+                "float_values",
+                "int_values",
+                "string_values"
+            ],
+            "properties": {
+                "float_values": {
+                    "enum": [
+                        14.5,
+                        16.789
+                    ],
+                    "oneOf": [
+                        {
+                            "const": 14.5
+                        },
+                        {
+                            "const": 16.789
+                        }
+                    ]
+                },
+                "int_values": {
+                    "enum": [
+                        1,
+                        3,
+                        6
+                    ],
+                    "oneOf": [
+                        {
+                            "const": 1
+                        },
+                        {
+                            "const": 3
+                        },
+                        {
+                            "const": 6
+                        }
+                    ]
+                },
+                "string_values": {
+                    "enum": [
+                        "budgie",
+                        "duck",
+                        "pigeon"
+                    ],
+                    "oneOf": [
+                        {
+                            "const": "budgie"
+                        },
+                        {
+                            "const": "duck"
+                        },
+                        {
+                            "const": "pigeon"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "type": "object"
+        }
+    }
+}

--- a/reflect.go
+++ b/reflect.go
@@ -90,8 +90,8 @@ type Type struct {
 	// RFC draft-wright-json-schema-hyperschema-00, section 4
 	Media          *Type  `json:"media,omitempty"`          // section 4.3
 	BinaryEncoding string `json:"binaryEncoding,omitempty"` // section 4.3
-	// I believe this is draft-06
-	Constant interface{} `json:"const,omitempty"` // section ?.?
+	// RFC draft-wright-json-schema-validation-01
+	Constant interface{} `json:"const,omitempty"` // section 6.24
 
 	Extras map[string]interface{} `json:"-"`
 }

--- a/reflect.go
+++ b/reflect.go
@@ -90,6 +90,8 @@ type Type struct {
 	// RFC draft-wright-json-schema-hyperschema-00, section 4
 	Media          *Type  `json:"media,omitempty"`          // section 4.3
 	BinaryEncoding string `json:"binaryEncoding,omitempty"` // section 4.3
+	// I believe this is draft-06
+	Constant interface{} `json:"const,omitempty"` // section ?.?
 
 	Extras map[string]interface{} `json:"-"`
 }

--- a/reflect.go
+++ b/reflect.go
@@ -517,6 +517,33 @@ func (t *Type) genericKeywords(tags []string, parentType *Type, propertyName str
 					f, _ := strconv.ParseFloat(val, 64)
 					t.Enum = append(t.Enum, f)
 				}
+			case "enum_const":
+				if t.OneOf == nil {
+					t.OneOf = make([]*Type, 0, 1)
+				}
+				constants := strings.Split(nameValue[1], ";")
+				for _, constantVal := range constants {
+					switch t.Type {
+					case "string":
+						t.Enum = append(t.Enum, constantVal)
+						t.OneOf = append(t.OneOf, &Type{
+							Constant: constantVal,
+						})
+					case "integer":
+						i, _ := strconv.Atoi(constantVal)
+						t.Enum = append(t.Enum, i)
+						t.OneOf = append(t.OneOf, &Type{
+							Constant: i,
+						})
+					case "number":
+						f, _ := strconv.ParseFloat(constantVal, 64)
+						t.Enum = append(t.Enum, f)
+						t.OneOf = append(t.OneOf, &Type{
+							Constant: f,
+						})
+					}
+				}
+				t.Type = ""
 			}
 		}
 	}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -2,7 +2,6 @@ package jsonschema
 
 import (
 	"encoding/json"
-	"github.com/iancoleman/orderedmap"
 	"io/ioutil"
 	"net"
 	"net/url"
@@ -11,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/iancoleman/orderedmap"
 
 	"github.com/stretchr/testify/require"
 )
@@ -222,6 +223,12 @@ type CustomMapOuter struct {
 	MyMap CustomMapType `json:"my_map"`
 }
 
+type EnumWithConstants struct {
+	FloatValues  float32 `json:"float_values" jsonschema:"enum_const=14.5;16.789"`
+	IntValues    int     `json:"int_values" jsonschema:"enum_const=1;3;6"`
+	StringValues string  `json:"string_values" jsonschema:"enum_const=budgie;duck;pigeon"`
+}
+
 func TestSchemaGeneration(t *testing.T) {
 	tests := []struct {
 		typ       interface{}
@@ -272,6 +279,7 @@ func TestSchemaGeneration(t *testing.T) {
 		{&CompactDate{}, &Reflector{}, "fixtures/compact_date.json"},
 		{&CustomSliceOuter{}, &Reflector{}, "fixtures/custom_slice_type.json"},
 		{&CustomMapOuter{}, &Reflector{}, "fixtures/custom_map_type.json"},
+		{&EnumWithConstants{}, &Reflector{}, "fixtures/enum_with_constants.json"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Hi @alecthomas. I'm using your JSONSchema library in one of my [projects](https://github.com/chrusty/protoc-gen-jsonschema), and recently someone has raised an issue where they would like to annotate the different values (with Title or Description) available in their ENUMs. It seems that a reasonable way to do this is to include a `OneOf` for each allowed value as a `const`, which looks like something that was introduced in draft-06.

At the moment I can just hack constants in by using the "Extras" map, and setting the schema version to "http://json-schema.org/draft-06/schema#", but this seems a little crufty.

I'm aware that this isn't a complate PR here - I just wanted to see what you make of this, and if you had any plans around extending the capabilities of this project with the newer JSONSchema draft standards? I'd be happy to contribute!