### PR TITLE
Allow Go code comments to be used as source of schema descriptions

### DIFF
--- a/comment_extractor.go
+++ b/comment_extractor.go
@@ -1,0 +1,90 @@
+package jsonschema
+
+import (
+	"fmt"
+	"io/fs"
+	gopath "path"
+	"path/filepath"
+	"strings"
+
+	"go/ast"
+	"go/doc"
+	"go/parser"
+	"go/token"
+)
+
+// ExtractGoComments will read all the go files contained in the provided path,
+// including sub-directories, in order to generate a dictionary of comments
+// associated with Types and Fields. The results will be added to the `commentsMap`
+// provided in the parameters and expected to be used for Schema "description" fields.
+//
+// The `go/parser` library is used to extract all the comments and unfortunately doesn't
+// have a built-in way to determine the fully qualified name of a package. The `base` paremeter,
+// the URL used to import that package, is thus required to be able to match reflected types.
+//
+// When parsing type comments, we use the `go/doc`'s Synopsis method to extract the first phrase
+// only. Field comments, which tend to be much short, will include everything.
+func ExtractGoComments(base, path string, commentMap map[string]string) error {
+	fset := token.NewFileSet()
+	dict := make(map[string][]*ast.Package)
+	err := filepath.Walk(path, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			d, err := parser.ParseDir(fset, path, nil, parser.ParseComments)
+			if err != nil {
+				return err
+			}
+			for _, v := range d {
+				// paths may have multiple packages, like for tests
+				k := gopath.Join(base, path)
+				dict[k] = append(dict[k], v)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for pkg, p := range dict {
+		for _, f := range p {
+			gtxt := ""
+			typ := ""
+			ast.Inspect(f, func(n ast.Node) bool {
+				switch x := n.(type) {
+				case *ast.TypeSpec:
+					typ = x.Name.String()
+					if !ast.IsExported(typ) {
+						typ = ""
+					} else {
+						txt := x.Doc.Text()
+						if txt == "" && gtxt != "" {
+							txt = gtxt
+							gtxt = ""
+						}
+						txt = doc.Synopsis(txt)
+						commentMap[fmt.Sprintf("%s.%s", pkg, typ)] = strings.TrimSpace(txt)
+					}
+				case *ast.Field:
+					txt := x.Doc.Text()
+					if typ != "" && txt != "" {
+						for _, n := range x.Names {
+							if ast.IsExported(n.String()) {
+								k := fmt.Sprintf("%s.%s.%s", pkg, typ, n)
+								commentMap[k] = strings.TrimSpace(txt)
+							}
+						}
+					}
+				case *ast.GenDecl:
+					// remember for the next type
+					gtxt = x.Doc.Text()
+				}
+				return true
+			})
+		}
+	}
+
+	return nil
+}

--- a/comment_extractor.go
+++ b/comment_extractor.go
@@ -23,7 +23,7 @@ import (
 // the URL used to import that package, is thus required to be able to match reflected types.
 //
 // When parsing type comments, we use the `go/doc`'s Synopsis method to extract the first phrase
-// only. Field comments, which tend to be much short, will include everything.
+// only. Field comments, which tend to be much shorter, will include everything.
 func ExtractGoComments(base, path string, commentMap map[string]string) error {
 	fset := token.NewFileSet()
 	dict := make(map[string][]*ast.Package)

--- a/examples/nested/nested.go
+++ b/examples/nested/nested.go
@@ -1,0 +1,15 @@
+package nested
+
+// Pet defines the user's fury friend.
+type Pet struct {
+	// Name of the animal.
+	Name string `json:"name" jsonschema:"title=Name"`
+}
+
+type (
+	// Plant represents the plants the user might have and serves as a test
+	// of structs inside a `type` set.
+	Plant struct {
+		Variant string `json:"variant" jsonschema:"title=Variant"` // This comment will be ignored
+	}
+)

--- a/examples/user.go
+++ b/examples/user.go
@@ -1,0 +1,22 @@
+package examples
+
+import (
+	"github.com/alecthomas/jsonschema/examples/nested"
+)
+
+// User is used as a base to provide tests for comments.
+// Don't forget to checkout the nested path.
+type User struct {
+	// Unique sequential identifier.
+	ID int `json:"id" jsonschema:"required"`
+	// This comment will be ignored
+	Name    string                 `json:"name" jsonschema:"required,minLength=1,maxLength=20,pattern=.*,description=this is a property,title=the name,example=joe,example=lucy,default=alex"`
+	Friends []int                  `json:"friends,omitempty" jsonschema_description:"list of IDs, omitted when empty"`
+	Tags    map[string]interface{} `json:"tags,omitempty"`
+
+	// An array of pets the user cares for.
+	Pets []*nested.Pet `json:"pets"`
+
+	// Set of plants that the user likes
+	Plants []*nested.Plant `json:"plants" jsonschema:"title=Pants"`
+}

--- a/fixtures/go_comments.json
+++ b/fixtures/go_comments.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/User",
+  "definitions": {
+    "Pet": {
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Name of the animal."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Pet defines the user's fury friend."
+    },
+    "Plant": {
+      "required": [
+        "variant"
+      ],
+      "properties": {
+        "variant": {
+          "type": "string",
+          "title": "Variant"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Plant represents the plants the user might have and serves as a test of structs inside a `type` set."
+    },
+    "User": {
+      "required": [
+        "id",
+        "name",
+        "pets",
+        "plants"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "description": "Unique sequential identifier."
+        },
+        "name": {
+          "maxLength": 20,
+          "minLength": 1,
+          "pattern": ".*",
+          "type": "string",
+          "title": "the name",
+          "description": "this is a property",
+          "default": "alex",
+          "examples": [
+            "joe",
+            "lucy"
+          ]
+        },
+        "friends": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array",
+          "description": "list of IDs, omitted when empty"
+        },
+        "tags": {
+          "patternProperties": {
+            ".*": {
+              "additionalProperties": true
+            }
+          },
+          "type": "object"
+        },
+        "pets": {
+          "items": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$ref": "#/definitions/Pet"
+          },
+          "type": "array",
+          "description": "An array of pets the user cares for."
+        },
+        "plants": {
+          "items": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$ref": "#/definitions/Plant"
+          },
+          "type": "array",
+          "title": "Pants",
+          "description": "Set of plants that the user likes"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "User is used as a base to provide tests for comments."
+    }
+  }
+}

--- a/reflect.go
+++ b/reflect.go
@@ -8,21 +8,12 @@ package jsonschema
 
 import (
 	"encoding/json"
-	"fmt"
-	"io/fs"
 	"net"
 	"net/url"
-	gopath "path"
-	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
-
-	"go/ast"
-	"go/doc"
-	"go/parser"
-	"go/token"
 
 	"github.com/iancoleman/orderedmap"
 )
@@ -894,82 +885,12 @@ func fullyQualifiedTypeName(t reflect.Type) string {
 	return t.PkgPath() + "." + t.Name()
 }
 
-// AddGoComments will read all the go files contained in the provided path,
-// including sub-directories, in order to generate a dictionary of comments
-// associated with Types and Fields. The results will be added to the `CommentsMap`
-// to be included in Schema "description" fields.
-//
-// The `go/parser` library is used to extract all the comments and unfortunately doesn't
-// have a built-in way to determine the fully qualified name of a package. The `base` paremeter,
-// the URL used to import that package, is thus required to be able to match reflected types.
-//
-// When parsing type comments, we use the `go/doc`'s Synopsis method to extract the first phrase
-// only. Field comments, which tend to be much short, will include everything.
+// AddGoComments will update the reflectors comment map with all the comments
+// found in the provided source directories. See the #ExtractGoComments method
+// for more details.
 func (r *Reflector) AddGoComments(base, path string) error {
 	if r.CommentMap == nil {
 		r.CommentMap = make(map[string]string)
 	}
-
-	fset := token.NewFileSet()
-	dict := make(map[string][]*ast.Package)
-	err := filepath.Walk(path, func(path string, info fs.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() {
-			d, err := parser.ParseDir(fset, path, nil, parser.ParseComments)
-			if err != nil {
-				return err
-			}
-			for _, v := range d {
-				// paths may have multiple packages, like for tests
-				k := gopath.Join(base, path)
-				dict[k] = append(dict[k], v)
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	for pkg, p := range dict {
-		for _, f := range p {
-			gtxt := ""
-			typ := ""
-			ast.Inspect(f, func(n ast.Node) bool {
-				switch x := n.(type) {
-				case *ast.TypeSpec:
-					typ = x.Name.String()
-					if !ast.IsExported(typ) {
-						typ = ""
-					} else {
-						txt := x.Doc.Text()
-						if txt == "" && gtxt != "" {
-							txt = gtxt
-							gtxt = ""
-						}
-						txt = doc.Synopsis(txt)
-						r.CommentMap[fmt.Sprintf("%s.%s", pkg, typ)] = strings.TrimSpace(txt)
-					}
-				case *ast.Field:
-					txt := x.Doc.Text()
-					if typ != "" && txt != "" {
-						for _, n := range x.Names {
-							if ast.IsExported(n.String()) {
-								k := fmt.Sprintf("%s.%s.%s", pkg, typ, n)
-								r.CommentMap[k] = strings.TrimSpace(txt)
-							}
-						}
-					}
-				case *ast.GenDecl:
-					// remember for the next type
-					gtxt = x.Doc.Text()
-				}
-				return true
-			})
-		}
-	}
-
-	return nil
+	return ExtractGoComments(base, path, r.CommentMap)
 }

--- a/reflect.go
+++ b/reflect.go
@@ -8,12 +8,21 @@ package jsonschema
 
 import (
 	"encoding/json"
+	"fmt"
+	"io/fs"
 	"net"
 	"net/url"
+	gopath "path"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
+
+	"go/ast"
+	"go/doc"
+	"go/parser"
+	"go/token"
 
 	"github.com/iancoleman/orderedmap"
 )
@@ -158,6 +167,22 @@ type Reflector struct {
 
 	// AdditionalFields allows adding structfields for a given type
 	AdditionalFields func(reflect.Type) []reflect.StructField
+
+	// CommentMap is a dictionary of fully qualified go types and fields to comment
+	// strings that will be used if a description has not already been provided in
+	// the tags. Types and fields are added to the package path using "." as a
+	// separator.
+	//
+	// Type descriptions should be defined like:
+	//
+	//   map[string]string{"github.com/alecthomas/jsonschema.Reflector": "A Reflector reflects values into a Schema."}
+	//
+	// And Fields defined as:
+	//
+	//   map[string]string{"github.com/alecthomas/jsonschema.Reflector.DoNotReference": "Do not reference definitions."}
+	//
+	// See also: AddGoComments
+	CommentMap map[string]string
 }
 
 // Reflect reflects to Schema from a value.
@@ -380,6 +405,7 @@ func (r *Reflector) reflectStruct(definitions Definitions, t reflect.Type) *Type
 		Type:                 "object",
 		Properties:           orderedmap.New(),
 		AdditionalProperties: []byte("false"),
+		Description:          r.lookupComment(t, ""),
 	}
 	if r.AllowAdditionalProperties {
 		st.AdditionalProperties = []byte("true")
@@ -425,6 +451,9 @@ func (r *Reflector) reflectStructFields(st *Type, definitions Definitions, t ref
 
 		property := r.reflectTypeToSchema(definitions, f.Type)
 		property.structKeywordsFromTags(f, st, name)
+		if property.Description == "" {
+			property.Description = r.lookupComment(t, f.Name)
+		}
 		if getFieldDocString != nil {
 			property.Description = getFieldDocString(f.Name)
 		}
@@ -457,6 +486,21 @@ func (r *Reflector) reflectStructFields(st *Type, definitions Definitions, t ref
 			}
 		}
 	}
+}
+
+func (r *Reflector) lookupComment(t reflect.Type, name string) string {
+	if r.CommentMap == nil {
+		return ""
+	}
+
+	n := fullyQualifiedTypeName(t)
+	if name != "" {
+		n = n + "." + name
+	}
+
+	fmt.Printf("Lookup: %v\n", n)
+
+	return r.CommentMap[n]
 }
 
 func (t *Type) structKeywordsFromTags(f reflect.StructField, parentType *Type, propertyName string) {
@@ -843,7 +887,91 @@ func (r *Reflector) typeName(t reflect.Type) string {
 		}
 	}
 	if r.FullyQualifyTypeNames {
-		return t.PkgPath() + "." + t.Name()
+		return fullyQualifiedTypeName(t)
 	}
 	return t.Name()
+}
+
+func fullyQualifiedTypeName(t reflect.Type) string {
+	return t.PkgPath() + "." + t.Name()
+}
+
+// AddGoComments will read all the go files contained in the provided path,
+// including sub-directories, in order to generate a dictionary of comments
+// associated with Types and Fields. The results will be added to the `CommentsMap`
+// to be included in Schema "description" fields.
+//
+// The `go/parser` library is used to extract all the comments and unfortunately doesn't
+// have a built-in way to determine the fully qualified name of a package. The `base` paremeter,
+// the URL used to import that package, is thus required to be able to match reflected types.
+//
+// When parsing type comments, we use the `go/doc`'s Synopsis method to extract the first phrase
+// only. Field comments, which tend to be much short, will include everything.
+func (r *Reflector) AddGoComments(base, path string) error {
+	if r.CommentMap == nil {
+		r.CommentMap = make(map[string]string)
+	}
+
+	fset := token.NewFileSet()
+	dict := make(map[string][]*ast.Package)
+	err := filepath.Walk(path, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			d, err := parser.ParseDir(fset, path, nil, parser.ParseComments)
+			if err != nil {
+				return err
+			}
+			for _, v := range d {
+				// paths may have multiple packages, like for tests
+				k := gopath.Join(base, path)
+				dict[k] = append(dict[k], v)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for pkg, p := range dict {
+		for _, f := range p {
+			gtxt := ""
+			typ := ""
+			ast.Inspect(f, func(n ast.Node) bool {
+				switch x := n.(type) {
+				case *ast.TypeSpec:
+					typ = x.Name.String()
+					if !ast.IsExported(typ) {
+						typ = ""
+					} else {
+						txt := x.Doc.Text()
+						if txt == "" && gtxt != "" {
+							txt = gtxt
+							gtxt = ""
+						}
+						txt = doc.Synopsis(txt)
+						r.CommentMap[fmt.Sprintf("%s.%s", pkg, typ)] = strings.TrimSpace(txt)
+					}
+				case *ast.Field:
+					txt := x.Doc.Text()
+					if typ != "" && txt != "" {
+						for _, n := range x.Names {
+							if ast.IsExported(n.String()) {
+								k := fmt.Sprintf("%s.%s.%s", pkg, typ, n)
+								r.CommentMap[k] = strings.TrimSpace(txt)
+							}
+						}
+					}
+				case *ast.GenDecl:
+					// remember for the next type
+					gtxt = x.Doc.Text()
+				}
+				return true
+			})
+		}
+	}
+
+	return nil
 }

--- a/reflect.go
+++ b/reflect.go
@@ -498,8 +498,6 @@ func (r *Reflector) lookupComment(t reflect.Type, name string) string {
 		n = n + "." + name
 	}
 
-	fmt.Printf("Lookup: %v\n", n)
-
 	return r.CommentMap[n]
 }
 

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -2,7 +2,6 @@ package jsonschema
 
 import (
 	"encoding/json"
-	"github.com/iancoleman/orderedmap"
 	"io/ioutil"
 	"net"
 	"net/url"
@@ -11,6 +10,10 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/iancoleman/orderedmap"
+
+	"github.com/alecthomas/jsonschema/examples"
 
 	"github.com/stretchr/testify/require"
 )
@@ -286,6 +289,7 @@ func TestSchemaGeneration(t *testing.T) {
 		{&CustomSliceOuter{}, &Reflector{}, "fixtures/custom_slice_type.json"},
 		{&CustomMapOuter{}, &Reflector{}, "fixtures/custom_map_type.json"},
 		{&CustomTypeFieldWithInterface{}, &Reflector{}, "fixtures/custom_type_with_interface.json"},
+		{&examples.User{}, prepareCommentReflector(t), "fixtures/go_comments.json"},
 	}
 
 	for _, tt := range tests {
@@ -305,6 +309,13 @@ func TestSchemaGeneration(t *testing.T) {
 			require.Equal(t, string(expectedJSON), string(actualJSON))
 		})
 	}
+}
+
+func prepareCommentReflector(t *testing.T) *Reflector {
+	r := new(Reflector)
+	err := r.AddGoComments("github.com/alecthomas/jsonschema", "./examples")
+	require.NoError(t, err, "did not expect error while adding comments")
+	return r
 }
 
 func TestBaselineUnmarshal(t *testing.T) {

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -312,6 +312,7 @@ func TestSchemaGeneration(t *testing.T) {
 }
 
 func prepareCommentReflector(t *testing.T) *Reflector {
+	t.Helper()
 	r := new(Reflector)
 	err := r.AddGoComments("github.com/alecthomas/jsonschema", "./examples")
 	require.NoError(t, err, "did not expect error while adding comments")


### PR DESCRIPTION
This is a bit of an experimental feature for consideration.

Our use-case is that we want to be able to use a single set of "descriptions" for both Go documentation and the generated JSON Schema. It get's boring very quickly adding both a comment describing a type of field, and a `jsonschema_description`.

This PR adds a `CommentsMap` property to the reflector which is essentially a dictionary that maps fully qualified package paths alongside types and fields, pointing to comment strings. 

The `AddGoComments` method included in the `Reflector` takes a base import module and a path, extracts all the comments, and adds them to the `CommentsMap`:

```go
r := new(jsonschema.Reflector)
if err := r.AddGoComments("github.com/alecthomas/jsonschema", "./examples"); err != nil {
  // deal with error
}
```

I couldn't figure out a way to automatically determine the full module name, so it has to be defined manually for each package you'd like to use comments from.

The end result is that you can define Go comments, and have them imported into your Schema. The tests provide a complete example of the results. One of the big advantages of this approach is that it makes it much easier to add descriptions to types.
